### PR TITLE
Added checking for pvs as this attribute should never be an empty list

### DIFF
--- a/acme/Validator.py
+++ b/acme/Validator.py
@@ -142,7 +142,15 @@ class Validator(object):
 				if p[reqp] == RO.NP:
 					Logging.logDebug('Found non-provision attribute: %s' % r)
 					return (False, C.rcBadRequest)
-
+				#Special case for lists that are not allowed to be empty (pvs in ACP)
+				if r in ['pvs']:
+					if jsn.get(r).len == 0:
+						Logging.logDebug('Attribute %s cannot be an empty list' % r)
+						return (False, C.rcBadRequest)
+					elif jsn.get(r).len == 1:
+						if jsn.get(r['acr'][0].len == 0):
+							Logging.logDebug('Attribute %s cannot be an empty list' % r)
+							return (False, C.rcBadRequest)
 			# Check whether the value is of the correct type
 			pt = p[0]	# type
 			pc = p[1]	# cardinality


### PR DESCRIPTION
Adding a checking for pvs so that it is not an empty list. Still there's an issue as it seems the attributePolicies for ACP is not constructed properly therefore it gets out of validateAttributes before this new checking.