### PR TITLE
WebUI: Adding settings button and button to toggle long attribute names

### DIFF
--- a/acme/webui/web/index.html
+++ b/acme/webui/web/index.html
@@ -21,6 +21,7 @@
 		<img class="brand logo" src="img/acme.png" />
 
 		<div class="menu"><label for="info1" class="pseudo" style="margin-left: 10px">&#9432;</label></div>
+		<div class="menu"><label for="webuiSettings1" class="pseudo" >Settings</label></div>
 		<div class="menu"><a id="refreshButton" href="javascript:toggleRefresh()"class="button" style="padding-left: 10px;">Auto Refresh</a></div>
 		<div class="menu"><a id="connectButton" href="javascript:connectToCSE()" class="button" style="padding-left: 10px;">Connect</a></div>
 
@@ -183,6 +184,25 @@
 	</section>
 	<footer>
 		<label align="right" for="info1" class="button" style="float: right;">Close</label>
+	</footer>
+</article>
+</div>
+
+<!-- WebUI Settings box -->
+<div class="modal">
+<input id="webuiSettings1" type="checkbox" />
+<label for="webuiSettings1" class="overlay"></label>
+<article>
+	<header>
+		<h3 float="left">ACME oneM2M CSE Web UI Settings</h3>
+		<span id="version" style="float: right"></span>
+	</header>
+	<section class="content">
+		<h3>View Settings</h3>
+        <div class="button" onclick="toggleLongAttributeNames()" >Toggle Attribute Name Style</div>
+	</section>
+	<footer>
+		<label align="right" for="webuiSettings1" class="button" style="float: right;">Close</label>
 	</footer>
 </article>
 </div>

--- a/acme/webui/web/js/contextmenu.js
+++ b/acme/webui/web/js/contextmenu.js
@@ -75,7 +75,7 @@ function ContextMenu(menu, options){
 
 
 
-			if(typeof item.type === "undefined"){
+			if(typeof item.type === "undefined" || item.type == ContextMenu.BUTTON){
 				var icon_span = document.createElement("span");
 				icon_span.className = 'cm_icon_span';
 
@@ -206,6 +206,7 @@ function ContextMenu(menu, options){
 
 ContextMenu.count = 0;
 ContextMenu.DIVIDER = "cm_divider";
+ContextMenu.BUTTON = "cm_button";
 
 const ContextUtil = {
 	getProperty: function(options, opt, def){

--- a/acme/webui/web/js/main.js
+++ b/acme/webui/web/js/main.js
@@ -239,6 +239,14 @@ function tabTo(number) {
 }
 
 
+function toggleLongAttributeNames() {
+  printLongNames = !printLongNames
+  clearAttributesTable()
+  if (nodeClicked.hasDetails) {
+    fillAttributesTable(nodeClicked.resource)        
+  }
+}
+
 function setup() {
   // document.body.style.zoom=0.6;
   this.blur();
@@ -274,11 +282,7 @@ function setup() {
     if (key == 'R' && e.ctrlKey) {
       refreshNode()
     } else if (key == 'H' && e.ctrlKey) {
-      printLongNames = !printLongNames
-      clearAttributesTable()
-      if (nodeClicked.hasDetails) {
-        fillAttributesTable(nodeClicked.resource)        
-      }
+      toggleLongAttributeNames();
     } else if (key == 'C' && e.ctrlKey) {
       connectToCSE();
     }

--- a/acme/webui/web/js/menu.js
+++ b/acme/webui/web/js/menu.js
@@ -10,8 +10,12 @@
 var cmenu = [
 			{
 				"text": "Refresh",
+                "type": ContextMenu.BUTTON,
 				"icon": '&#x27F3;',
 				"events": {
+                    "checkEnabled": function (ty) {
+                        return true; 
+                    },
 					"click": function(e) {
 						refreshNode()
 					}
@@ -19,9 +23,14 @@ var cmenu = [
 			},
 			{
 				"text": "Connect to",
+                "type": ContextMenu.BUTTON,
 				"icon": '&#8594;',
 				"enabled" : false,
 				"events": {
+                    "checkEnabled": function (ty) {
+                        // Can only do connection to CSR type
+                        return ty == 16; 
+                    },
 					"click": function(e) {
 						openPOA(nodeClicked)
 					}
@@ -42,29 +51,36 @@ var cmenu = [
 				"text": "Delete",
 				"icon": '&#x21;',
 				"enabled" : false,
-
+                "type": ContextMenu.BUTTON,
 				"events": {
+                    "checkEnabled": function (ty) {
+                        // Don't allow deletion of the CSE!
+                        return ty != 5; 
+                    },
 					"click": function(e) {
 						removeNode(nodeClicked)
 					}
 				}
-			}
+			},
 		];
 
-var menu
+var menu;
 
 function showContextMenu(event, node) {
-  nodeClicked.setSelected(false)
-  nodeClicked = node
-  
-  // CSE
-  cmenu[3]["enabled"] = (node.resource.ty != 5) 
+  nodeClicked.setSelected(false);
+  nodeClicked = node;
 
-  // CSR
-  cmenu[1]["enabled"] = (node.resource.ty == 16) 
+  for (var i = 0; i < cmenu.length; i++){
+    var item = cmenu[i];
+    if (item.type == ContextMenu.DIVIDER) {
+        // Don't check enable for a divider
+        continue;
+    }
+    cmenu[i]["enabled"] = item.events.checkEnabled(node.resource.ty); 
+  }
 
   nodeClicked.setSelected(true)
-  menu.reload()
+  menu.reload();
   menu.display(event);
 }
 


### PR DESCRIPTION
Hello, this is a small feature I'd like to add in to ACME.

The `Ctrl+H` hot key for toggling the long/short attribute names does not work in my browser (Firefox 106.0.2).   
Instead, it pulls up my browser history, which is quite annoying. I'm sure this is probably a problem for other web browsers.

My changes do the following:
- Adds an additional modal dialog box for managing settings related to the WebUI
- Adds a button to the new settings modal box for toggling between long/short attribute names
- Moves logic for toggling long/short attribute names from inside of `setup()` and into a globally accessible function `toggleLongAttributeNames()`