### PR TITLE
Fixing case when HTTP Response status is an unhandled value

### DIFF
--- a/acme/webui/web/js/restui.js
+++ b/acme/webui/web/js/restui.js
@@ -124,6 +124,10 @@ function restSendData(method, url, headers, data) {
 				case 404: s = '404 - Not Found'; break;
 				case 405: s = '405 - Method Not Allowed'; break;
 				case 409: s = '409 - Conflict'; break;
+                default:
+                    s = this.status;
+                    console.warn("Unhandled HTTP response code! " + s);
+                break;
 			}
 			document.getElementById("rest-status").value = s;
 


### PR DESCRIPTION
In the Web UI, there is a missing case in the switch statement for handling the display of the HTTP response from the CSE.
If there is an error (ie. response code 500), this switch statement would fail to make an assignment, which results in the variable `s` being undefined, so nothing gets displayed in the response body.

My small change adds a default case to the switch statement to catch this error case so that everything prints as expected.