### PR TITLE
MQTTS Support for Notification Server added

### DIFF
--- a/acme/helpers/MQTTConnection.py
+++ b/acme/helpers/MQTTConnection.py
@@ -1,14 +1,15 @@
 #
-#	MQTTConnection.py
+# MQTTConnection.py
 #
-#	(c) 2021 by Andreas Kraft
-#	License: BSD 3-Clause License. See the LICENSE file for further details.
+# (c) 2021 by Andreas Kraft
+# License: BSD 3-Clause License. See the LICENSE file for further details.
 #
-#	Implementation of an MQTT Client helper class.
+# Implementation of an MQTT Client helper class.
 #
 
 from __future__ import annotations
-import ssl, time
+import ssl
+import time
 from dataclasses import dataclass
 from typing import Callable, Any, Tuple
 import logging
@@ -18,63 +19,64 @@ from .TextTools import simpleMatch
 
 import paho.mqtt.client as mqtt
 
+
 @dataclass
 class MQTTTopic:
-	"""	Structure that represents a subscribed-to topic.
-	"""
-	topic:str				= None
-	mid:int					= None
-	isSubscribed:bool		= False
-	callback:MQTTCallback	= None
-	callbackArgs:dict 		= None
+    """	Structure that represents a subscribed-to topic.
+    """
+    topic: str = None
+    mid: int = None
+    isSubscribed: bool = False
+    callback: MQTTCallback = None
+    callbackArgs: dict = None
 
 
 class MQTTHandler(object):
-	"""	This base class defines the interface for an MQTT handler class. 
-		The abstract methods defined here must be implemented by the implementing class.
+    """	This base class defines the interface for an MQTT handler class.
+            The abstract methods defined here must be implemented by the implementing class.
 
-		The implementing class acts as a handler for various callbacks when dealing with
-		the MQTT handler. To receive messages a client implementation must register topics
-		and the callbacks for them in the `onConnect()` method.
-	"""
+            The implementing class acts as a handler for various callbacks when dealing with
+            the MQTT handler. To receive messages a client implementation must register topics
+            and the callbacks for them in the `onConnect()` method.
+    """
 
-	def onConnect(self, connection:MQTTConnection) -> bool:
-		"""	This method is called after the MQTT client connected to the MQTT broker. 
-			Usually, an MQTT client should subscribe to topics and register the callback
-			methods here.
-		"""
-		return True
+    def onConnect(self, connection: MQTTConnection) -> bool:
+        """	This method is called after the MQTT client connected to the MQTT broker.
+                Usually, an MQTT client should subscribe to topics and register the callback
+                methods here.
+        """
+        return True
 
-	def onDisconnect(self, connection:MQTTConnection) -> bool:
-		"""	This method is called after the MQTT client disconnected from the MQTT broker. 
-		"""
-		return True
+    def onDisconnect(self, connection: MQTTConnection) -> bool:
+        """	This method is called after the MQTT client disconnected from the MQTT broker.
+        """
+        return True
 
-	def onSubscribed(self, connection:MQTTConnection, topic:str) -> bool:
-		"""	This method is called after the MQTT client successfully subsribed to a topic. 
-		"""
-		connection.subscribedCount += 1
-		return True
+    def onSubscribed(self, connection: MQTTConnection, topic: str) -> bool:
+        """	This method is called after the MQTT client successfully subsribed to a topic.
+        """
+        connection.subscribedCount += 1
+        return True
 
-	def onUnsubscribed(self, connection:MQTTConnection, topic:str) -> bool:
-		"""	This method is called after the MQTT client successfully unsubsribed from a topic. 
-		"""
-		connection.subscribedCount -= 1
-		return True
+    def onUnsubscribed(self, connection: MQTTConnection, topic: str) -> bool:
+        """	This method is called after the MQTT client successfully unsubsribed from a topic.
+        """
+        connection.subscribedCount -= 1
+        return True
 
-	def onError(self, connection:MQTTConnection, rc:int) -> bool:
-		"""	This method is called when receiving an error when communicating with the MQTT broker. 
-		"""
-		return True
+    def onError(self, connection: MQTTConnection, rc: int) -> bool:
+        """	This method is called when receiving an error when communicating with the MQTT broker.
+        """
+        return True
 
-	def logging(self, connection:MQTTConnection, level:int, message:str) -> bool:
-		"""	This method is called when a log message should be handled. 
-		"""
-		return True
-	
-	def onShutdown(self, connection:MQTTConnection) -> None:
-		"""	This method is called after the ```connection``` was shut down.
-		"""
+    def logging(self, connection: MQTTConnection, level: int, message: str) -> bool:
+        """	This method is called when a log message should be handled.
+        """
+        return True
+
+    def onShutdown(self, connection: MQTTConnection) -> None:
+        """	This method is called after the ```connection``` was shut down.
+        """
 
 
 ##############################################################################
@@ -82,288 +84,318 @@ class MQTTHandler(object):
 
 class MQTTConnection(object):
 
-	#
-	#	Runtime methods
-	#
+    #
+    # Runtime methods
+    #
 
-	def __init__(self, address:str, port:int=None, keepalive:int=60, interface:str='0.0.0.0', 
-					clientID:str=None, username:str=None, password:str=None,
-					useTLS:bool=False, caFile:str=None, verifyCertificate:bool=False,
-					lowLevelLogging:bool=True,
-					messageHandler:MQTTHandler=None
-				) -> None:
-		self.address								= address
-		self.port									= port if port else 4883 if useTLS else 1883
-		self.keepalive								= keepalive
-		self.bindIF									= interface
-		self.username:str							= username
-		self.password:str 							= password
-		self.useTLS:bool							= useTLS
-		self.verifyCertificate						= verifyCertificate
-		self.caFile									= caFile
-		self.clientID								= clientID
-		self.lowLevelLogging						= lowLevelLogging
+    def __init__(self, address: str, port: int = None, keepalive: int = 60, interface: str = '0.0.0.0',
+                 clientID: str = None, username: str = None, password: str = None,
+                 useTLS: bool = False, cafile: str = None, verifyCertificate: bool = False, certfile: str = None, keyfile: str = None,
+                 lowLevelLogging: bool = True,
+                 messageHandler: MQTTHandler = None
+                 ) -> None:
+        self.address = address
+        self.port = port if port else 4883 if useTLS else 1883
+        self.keepalive = keepalive
+        self.bindIF = interface
+        self.username: str = username
+        self.password: str = password
+        self.useTLS: bool = useTLS
+        self.verifyCertificate = verifyCertificate
+        self.caFile = cafile
+        # MIO_AID MQTTS Added 09.11.2022 START
+        self.mqttsCertfile = certfile
+        self.mqttsKeyfile = keyfile
+    # END
+        self.clientID = clientID
+        self.lowLevelLogging = lowLevelLogging
 
-		self.isStopped								= True
-		self.isConnected							= False
-		self.subscribedCount 						= 0
+        self.isStopped = True
+        self.isConnected = False
+        self.subscribedCount = 0
 
+        self.mqttClient: mqtt.Client = None
+        self.messageHandler: MQTTHandler = messageHandler
+        self.actor: BackgroundWorker = None
+        self.subscribedTopics: dict[str, MQTTTopic] = {}
 
-		self.mqttClient:mqtt.Client 				= None
-		self.messageHandler:MQTTHandler				= messageHandler
-		self.actor:BackgroundWorker 				= None
-		self.subscribedTopics:dict[str, MQTTTopic]	= {}
+    def shutdown(self) -> bool:
+        """	Shutting down the MQTT client.
+        """
 
-	
-	def shutdown(self) -> bool:
-		"""	Shutting down the MQTT client.
-		"""
+        self.isStopped = True
+        if self.mqttClient:
+            # if self.mqttClient and self.isConnected:
+            # Unsubscribe from all topics
+            for t in list(self.subscribedTopics.values()):
+                self.unsubscribeTopic(t)
+            # wait a moment for all unsubscribe ACKs to arrive
+            while len(self.subscribedTopics) > 0:
+                time.sleep(0.1)
+            # Then disconnect. The actor is stoped implicitly
+            self.mqttClient.disconnect()
+            self.actor = None
 
-		self.isStopped = True
-		if self.mqttClient:
-		# if self.mqttClient and self.isConnected:
-			# Unsubscribe from all topics
-			for t in list(self.subscribedTopics.values()):
-				self.unsubscribeTopic(t)
-			# wait a moment for all unsubscribe ACKs to arrive
-			while len(self.subscribedTopics) > 0:
-				time.sleep(0.1)
-			# Then disconnect. The actor is stoped implicitly
-			self.mqttClient.disconnect()
-			self.actor = None
+        self.messageHandler and self.messageHandler.logging(
+            self.mqttClient, logging.INFO, 'MQTT client shut down')
+        return True
 
-		self.messageHandler and self.messageHandler.logging(self.mqttClient, logging.INFO, 'MQTT client shut down')
-		return True
+    # def ssl_alpn(self) -> ssl.SSLContext:
+    #     try:
+    #         #debug print opnessl version
+    #         ssl_context = ssl.create_default_context()
+    #         ssl_context.load_verify_locations(cafile=self.caFile)
+    #         ssl_context.load_cert_chain(certfile=self.mqttsCertfile, keyfile=self.mqttsKeyfile)
 
+    #         return  ssl_context
+    #     except Exception as e:
+    #         print("exception ssl_alpn()")
+    #         raise e
 
-	def run(self) -> None:
-		"""	Initialize and run the MQTT client as a BackgroundWorker/Actor.
-		"""
-		self.messageHandler and self.messageHandler.logging(self.mqttClient, logging.DEBUG, f'MQTT: client name: {self.clientID}')
-		self.mqttClient = mqtt.Client(client_id=self.clientID, clean_session=False if self.clientID else True)	# clean_session=False is defined by TS-0010
+    def run(self) -> None:
+        """	Initialize and run the MQTT client as a BackgroundWorker/Actor.
+        """
+        self.messageHandler and self.messageHandler.logging(
+            self.mqttClient, logging.DEBUG, f'MQTT: client name: {self.clientID}')
+        # clean_session=False is defined by TS-0010
+        self.mqttClient = mqtt.Client(
+            client_id=self.clientID, clean_session=False if self.clientID else True)
 
-		# Enable SSL
-		if self.useTLS:
-			self.mqttClient.tls_set(ca_certs=self.caFile, cert_reqs=ssl.CERT_REQUIRED if self.verifyCertificate else ssl.CERT_NONE)
+        # Enable SSL
+        if self.useTLS:
+            self.mqttClient.tls_set(ca_certs=self.caFile, certfile=self.mqttsCertfile, keyfile=self.mqttsKeyfile, cert_reqs=ssl.CERT_REQUIRED, tls_version=ssl.PROTOCOL_TLS, ciphers=None)
+            #self.mqttClient.tls_set(ca_certs=self.caFile, cert_reqs=ssl.CERT_REQUIRED if self.verifyCertificate else ssl.CERT_NONE)
 
-		# Set username/password
-		if self.username and self.password:
-			self.mqttClient.username_pw_set(self.username, self.password)
-		
-		self.mqttClient.on_connect 		= self._onConnect
-		self.mqttClient.on_disconnect	= self._onDisconnect
-		self.mqttClient.on_log			= self._onLog
-		self.mqttClient.on_subscribe	= self._onSubscribe
-		self.mqttClient.on_unsubscribe	= self._onUnsubscribe
-		self.mqttClient.on_message		= self._onMessage
+            # Set username/password
+        if self.username and self.password:
+            self.mqttClient.username_pw_set(self.username, self.password)
 
-		try:
-			self.messageHandler and self.messageHandler.logging(self.mqttClient, logging.DEBUG, f'MQTT: connecting to host:{self.address}, port:{self.port}, keepalive: {self.keepalive}, bind: {self.bindIF}')
-			self.mqttClient.connect(host=self.address, port=self.port, keepalive=self.keepalive, bind_address=self.bindIF)
-		except Exception as e:
-			if self.messageHandler:
-				self.messageHandler.logging(self.mqttClient, logging.ERROR, f'MQTT: cannot connect to broker: {e}')
-				self.messageHandler.onError(self, -1)
+        self.mqttClient.on_connect = self._onConnect
+        self.mqttClient.on_disconnect = self._onDisconnect
+        self.mqttClient.on_log = self._onLog
+        self.mqttClient.on_subscribe = self._onSubscribe
+        self.mqttClient.on_unsubscribe = self._onUnsubscribe
+        self.mqttClient.on_message = self._onMessage
 
-		# Actually start the actor to run the MQTT client as a thread
-		self.actor = BackgroundWorkerPool.newActor(self._mqttActor, name='MQTTClient').start()
+        try:
+            self.messageHandler and self.messageHandler.logging(
+                self.mqttClient, logging.DEBUG, f'MQTT: connecting to host:{self.address}, port:{self.port}, keepalive: {self.keepalive}, bind: {self.bindIF}')
+            self.mqttClient.connect(
+                host=self.address, port=self.port, keepalive=self.keepalive, bind_address=self.bindIF)
+        except Exception as e:
+            if self.messageHandler:
+                self.messageHandler.logging(
+                    self.mqttClient, logging.ERROR, f'MQTT: cannot connect to broker: {e}')
+                self.messageHandler.onError(self, -1)
 
+        # Actually start the actor to run the MQTT client as a thread
+        self.actor = BackgroundWorkerPool.newActor(
+            self._mqttActor, name='MQTTClient').start()
 
-	def _mqttActor(self) -> bool:
-		"""	Backgroundworker callback to run the actuall MQTT loop.
-		"""
-		self.isStopped = False
-		self.messageHandler and self.messageHandler.logging(self.mqttClient, logging.INFO, 'MQTT: client started')
-		while not self.isStopped:
-			self.mqttClient.loop_forever()	# Will return when disconnect() is called
-		if self.messageHandler:
-			self.messageHandler.onShutdown(self)
-		return True
-	
-	
-	#
-	#	MQTT/paho callbacks
-	#
+    def _mqttActor(self) -> bool:
+        """	Backgroundworker callback to run the actuall MQTT loop.
+        """
+        self.isStopped = False
+        self.messageHandler and self.messageHandler.logging(
+            self.mqttClient, logging.INFO, 'MQTT: client started')
+        while not self.isStopped:
+            self.mqttClient.loop_forever()  # Will return when disconnect() is called
+        if self.messageHandler:
+            self.messageHandler.onShutdown(self)
+        return True
 
-	def _onConnect(self, client:mqtt.Client, userdata:Any, flags:dict, rc:int) -> None:
-		"""	Callback when the MQTT client connected to the broker.
-		"""
-		self.messageHandler and self.messageHandler.logging(self, logging.DEBUG, f'MQTT: Connected with result code: {rc} ({mqtt.error_string(rc)})')
-		if rc == 0:
-			self.isConnected = True
-			self.messageHandler and self.messageHandler.onConnect(self)
-		else:
-			self.isConnected = False
-			if self.messageHandler:
-				self.messageHandler.logging(self, logging.ERROR, f'MQTT: Cannot connect to broker. Result code: {rc} ({mqtt.error_string(rc)})')
-				self.messageHandler.onError(self, rc)
+    #
+    # MQTT/paho callbacks
+    #
 
+    def _onConnect(self, client: mqtt.Client, userdata: Any, flags: dict, rc: int) -> None:
+        """	Callback when the MQTT client connected to the broker.
+        """
+        self.messageHandler and self.messageHandler.logging(
+            self, logging.DEBUG, f'MQTT: Connected with result code: {rc} ({mqtt.error_string(rc)})')
+        if rc == 0:
+            self.isConnected = True
+            self.messageHandler and self.messageHandler.onConnect(self)
+        else:
+            self.isConnected = False
+            if self.messageHandler:
+                self.messageHandler.logging(
+                    self, logging.ERROR, f'MQTT: Cannot connect to broker. Result code: {rc} ({mqtt.error_string(rc)})')
+                self.messageHandler.onError(self, rc)
 
-	def _onDisconnect(self, client:mqtt.Client, userdata:Any, rc:int) -> None:
-		"""	Callback when the MQTT client disconnected from the broker.
-		"""
-		self.messageHandler and self.messageHandler.logging(self, logging.DEBUG, f'MQTT: Disconnected with result code: {rc} ({mqtt.error_string(rc)})')
-		self.subscribedTopics.clear()
-		if rc == 0:
-			self.isConnected = False
-			self.messageHandler and	self.messageHandler.onDisconnect(self)
-		elif rc == 7:
-			self.isConnected = False
-			self.messageHandler.logging(self, logging.ERROR, f'MQTT: Cannot disconnect from broker. Result code: {rc} ({mqtt.error_string(rc)})')
-			self.messageHandler.logging(self, logging.ERROR, f'MQTT: Did another client connected with the same ID ({self.clientID})?')
-			self.messageHandler and	self.messageHandler.onDisconnect(self)
-		else:
-			self.isConnected = False
-			if self.messageHandler:
-				self.messageHandler.logging(self, logging.ERROR, f'MQTT: Cannot disconnect from broker. Result code: {rc} ({mqtt.error_string(rc)})')
-				self.messageHandler.onDisconnect(self)
-				self.messageHandler.onError(self, rc)
+    def _onDisconnect(self, client: mqtt.Client, userdata: Any, rc: int) -> None:
+        """	Callback when the MQTT client disconnected from the broker.
+        """
+        self.messageHandler and self.messageHandler.logging(
+            self, logging.DEBUG, f'MQTT: Disconnected with result code: {rc} ({mqtt.error_string(rc)})')
+        self.subscribedTopics.clear()
+        if rc == 0:
+            self.isConnected = False
+            self.messageHandler and self.messageHandler.onDisconnect(self)
+        elif rc == 7:
+            self.isConnected = False
+            self.messageHandler.logging(
+                self, logging.ERROR, f'MQTT: Cannot disconnect from broker. Result code: {rc} ({mqtt.error_string(rc)})')
+            self.messageHandler.logging(
+                self, logging.ERROR, f'MQTT: Did another client connected with the same ID ({self.clientID})?')
+            self.messageHandler and self.messageHandler.onDisconnect(self)
+        else:
+            self.isConnected = False
+            if self.messageHandler:
+                self.messageHandler.logging(
+                    self, logging.ERROR, f'MQTT: Cannot disconnect from broker. Result code: {rc} ({mqtt.error_string(rc)})')
+                self.messageHandler.onDisconnect(self)
+                self.messageHandler.onError(self, rc)
 
+    def _onLog(self, client: mqtt.Client, userdata: Any, level: int, buf: str) -> None:
+        """	Mapping of the paho MQTT client's log to the logging system. Also handles different log-level scheme.
+        """
+        self.lowLevelLogging and self.messageHandler and self.messageHandler.logging(
+            self, mqtt.LOGGING_LEVEL[level], f'MQTT: {buf}')
 
-	def _onLog(self, client:mqtt.Client, userdata:Any, level:int, buf:str) -> None:
-		"""	Mapping of the paho MQTT client's log to the logging system. Also handles different log-level scheme.
-		"""
-		self.lowLevelLogging and self.messageHandler and self.messageHandler.logging(self, mqtt.LOGGING_LEVEL[level], f'MQTT: {buf}')
-	
+    def _onSubscribe(self, client: mqtt.Client, userdata: Any, mid: int, granted_qos: int) -> None:
+        # TODO doc, error check when not connected, not subscribed
+        for t in self.subscribedTopics.values():
+            if t.mid == mid:
+                t.isSubscribed = True
+                self.messageHandler and self.messageHandler.onSubscribed(
+                    self, t.topic)
+                break
 
-	def _onSubscribe(self, client:mqtt.Client, userdata:Any, mid:int, granted_qos:int) -> None:
-		# TODO doc, error check when not connected, not subscribed
-		for t in self.subscribedTopics.values():
-			if t.mid == mid:
-				t.isSubscribed = True
-				self.messageHandler and self.messageHandler.onSubscribed(self, t.topic)
-				break
-	
+    def _onUnsubscribe(self, client: mqtt.Client, userdata: Any, mid: int) -> None:
+        # TODO doc, error check when not connected, not subscribed
+        """	Callback when the client successfulle unsubscribed from a topic. The topic
+                is also removed from the internal list.
+        """
+        for t in self.subscribedTopics.values():
+            if t.mid == mid:
+                del self.subscribedTopics[t.topic]
+                self.messageHandler and self.messageHandler.onUnsubscribed(
+                    self, t.topic)
+                break
 
-	def _onUnsubscribe(self, client:mqtt.Client, userdata:Any, mid:int) -> None:
-		# TODO doc, error check when not connected, not subscribed
-		"""	Callback when the client successfulle unsubscribed from a topic. The topic
-			is also removed from the internal list.
-		"""
-		for t in self.subscribedTopics.values():
-			if t.mid == mid:
-				del self.subscribedTopics[t.topic]
-				self.messageHandler and self.messageHandler.onUnsubscribed(self, t.topic)
-				break
+    def _onMessage(self, client: mqtt.Client, userdata: Any, message: mqtt.MQTTMessage) -> None:
+        """	Handle a received message. Forward it to the apropriate handler callback (in a Thread)
+        """
+        self.lowLevelLogging and self.messageHandler and self.messageHandler.logging(
+            self, logging.DEBUG, f'MQTT: received topic:{message.topic}, payload:{message.payload}')
+        for t in self.subscribedTopics.keys():
+            if simpleMatch(message.topic, t, star='#'):
+                if (topic := self.subscribedTopics[t]).callback:
+                    # Run actual request handling in a thread
+                    # For some reasons mid is not initialized in the on on_message callback, so we use the timestamp for the actor name
+                    BackgroundWorkerPool.newActor(topic.callback, name=f'mid_{message.timestamp}').start(connection=self,
+                                                                                                         topic=message.topic,
+                                                                                                         data=message.payload,
+                                                                                                         **topic.callbackArgs)
+                    break  # break at first occurence
 
+    #
+    # MQTT messaging methods
+    #
 
-	def _onMessage(self, client:mqtt.Client, userdata:Any, message:mqtt.MQTTMessage) -> None:
-		"""	Handle a received message. Forward it to the apropriate handler callback (in a Thread)
-		"""
-		self.lowLevelLogging and self.messageHandler and self.messageHandler.logging(self, logging.DEBUG, f'MQTT: received topic:{message.topic}, payload:{message.payload}')
-		for t in self.subscribedTopics.keys():
-			if simpleMatch(message.topic, t, star='#'):
-				if (topic := self.subscribedTopics[t]).callback:
-					# Run actual request handling in a thread
-					# For some reasons mid is not initialized in the on on_message callback, so we use the timestamp for the actor name
-					BackgroundWorkerPool.newActor(topic.callback, name=f'mid_{message.timestamp}').start(	connection=self,
-																											topic=message.topic,
-																											data=message.payload, 
-																											**topic.callbackArgs)
-					break	# break at first occurence
+    def subscribeTopic(self, topic: str | list[str], callback: MQTTCallback = None, **kwargs: Any) -> None:
+        """	Add one or more MQTT topics to subscribe to. Add the topic(s) afterwards
+                to the list of subscribed-to topics.
+        """
+        def _subscribe(topic: str) -> None:
+            """	Handle subscription of a single topic.
+            """
+            if topic in self.subscribedTopics:
+                self.messageHandler and self.messageHandler.logging(
+                    self.mqttClient, logging.WARNING, f'MQTT: topic already subscribed: {topic}')
+                return
+            if (r := self.mqttClient.subscribe(topic))[0] == 0:
+                t = MQTTTopic(
+                    topic=topic, mid=r[1], callback=callback, callbackArgs=kwargs)
+                self.subscribedTopics[topic] = t
+            else:
+                self.messageHandler and self.messageHandler.logging(
+                    self.mqttClient, logging.ERROR, f'MQTT: cannot subscribe: {r[0]}')
 
+        if not self.mqttClient or not self.isConnected:
+            self.messageHandler and self.messageHandler.logging(
+                self.mqttClient, logging.ERROR, 'MQTT: Client missing or not initialized')
+            return
 
-	#
-	#	MQTT messaging methods
-	#
+        # either subscribe a list of topics or a single topic
+        list(map(_subscribe, topic if isinstance(topic, list) else [topic]))
 
-	def subscribeTopic(self, topic:str|list[str], callback:MQTTCallback=None, **kwargs:Any) -> None:
-		"""	Add one or more MQTT topics to subscribe to. Add the topic(s) afterwards
-			to the list of subscribed-to topics.
-		"""
-		def _subscribe(topic:str) -> None:
-			"""	Handle subscription of a single topic.
-			"""
-			if topic in self.subscribedTopics:
-				self.messageHandler and self.messageHandler.logging(self.mqttClient, logging.WARNING, f'MQTT: topic already subscribed: {topic}')
-				return
-			if (r := self.mqttClient.subscribe(topic))[0] == 0:
-				t = MQTTTopic(topic = topic, mid=r[1], callback=callback, callbackArgs=kwargs)
-				self.subscribedTopics[topic] = t
-			else:
-				self.messageHandler and self.messageHandler.logging(self.mqttClient, logging.ERROR, f'MQTT: cannot subscribe: {r[0]}')
+    def unsubscribeTopic(self, topic: str | MQTTTopic) -> None:
+        """	Unsubscribe from a topic. `topic` is either an MQTTTopic structure with
+                a previously subscribed to topic, or a topic name, in which case
+                it is searched for in the list of MQTTTopics.
+        """
+        if isinstance(topic, MQTTTopic):
+            if topic.topic not in self.subscribedTopics:
+                self.messageHandler and self.messageHandler.logging(
+                    self.mqttClient, logging.WARNING, f'MQTT: unknown topic: {topic.topic}')
+                return
+            if (r := self.mqttClient.unsubscribe(topic.topic))[0] == 0:
+                topic.mid = r[1]
+            else:
+                self.messageHandler and self.messageHandler.logging(
+                    self.mqttClient, logging.ERROR, f'MQTT: cannot unsubscribe: {r[0]}')
+                return
 
-		if not self.mqttClient or not self.isConnected:
-			self.messageHandler and self.messageHandler.logging(self.mqttClient, logging.ERROR, 'MQTT: Client missing or not initialized')
-			return
+        else:  # if topic is just the name we need to subscribe to
+            if topic not in self.subscribedTopics:
+                self.messageHandler and self.messageHandler.logging(
+                    self.mqttClient, logging.WARNING, f'MQTT: unknown topic: {topic}')
+                return
+            t = self.subscribedTopics[topic]
+            if t.isSubscribed:
+                if (r := self.mqttClient.unsubscribe(t.topic))[0] == 0:
+                    t.mid = r[1]
+                else:
+                    self.messageHandler and self.messageHandler.logging(
+                        self.mqttClient, logging.ERROR, f'MQTT: cannot unsubscribe: {r[0]}')
+                    return
+            else:
+                self.messageHandler and self.messageHandler.logging(
+                    self.mqttClient, logging.WARNING, f'MQTT: topic not subscribed: {topic}')
 
-		# either subscribe a list of topics or a single topic
-		list(map(_subscribe, topic if isinstance(topic, list) else [topic]))
+        # topic is removed in _onUnsubscribe() callback
 
+    def isFullySubscribed(self) -> bool:
+        """	Check whether the number managed subscriptions matches the number of
+                currently subscribed-to topics.
+        """
+        return self.subscribedCount == len(self.subscribedTopics)
 
-	def unsubscribeTopic(self, topic:str|MQTTTopic) -> None:
-		"""	Unsubscribe from a topic. `topic` is either an MQTTTopic structure with
-			a previously subscribed to topic, or a topic name, in which case
-			it is searched for in the list of MQTTTopics.
-		"""
-		if isinstance(topic, MQTTTopic):
-			if topic.topic not in self.subscribedTopics:
-				self.messageHandler and self.messageHandler.logging(self.mqttClient, logging.WARNING, f'MQTT: unknown topic: {topic.topic}')
-				return
-			if (r := self.mqttClient.unsubscribe(topic.topic))[0] == 0:
-				topic.mid = r[1]
-			else:
-				self.messageHandler and self.messageHandler.logging(self.mqttClient, logging.ERROR, f'MQTT: cannot unsubscribe: {r[0]}')
-				return
-
-		else:	# if topic is just the name we need to subscribe to
-			if topic not in self.subscribedTopics:
-				self.messageHandler and self.messageHandler.logging(self.mqttClient, logging.WARNING, f'MQTT: unknown topic: {topic}')
-				return
-			t = self.subscribedTopics[topic]
-			if t.isSubscribed:
-				if (r := self.mqttClient.unsubscribe(t.topic))[0] == 0:
-					t.mid = r[1]
-				else:
-					self.messageHandler and self.messageHandler.logging(self.mqttClient, logging.ERROR, f'MQTT: cannot unsubscribe: {r[0]}')
-					return
-			else:
-				self.messageHandler and self.messageHandler.logging(self.mqttClient, logging.WARNING, f'MQTT: topic not subscribed: {topic}')
-
-		# topic is removed in _onUnsubscribe() callback
-
-
-	def isFullySubscribed(self) -> bool:
-		"""	Check whether the number managed subscriptions matches the number of
-			currently subscribed-to topics.
-		"""
-		return self.subscribedCount == len(self.subscribedTopics)
-
-
-
-	def publish(self, topic:str, data:bytes) -> None:
-		"""	Publish the message `data` with the topic `topic` with the MQTT broker.
-		"""
-		self.mqttClient.publish(topic, data)
-
+    def publish(self, topic: str, data: bytes) -> None:
+        """	Publish the message `data` with the topic `topic` with the MQTT broker.
+        """
+        self.mqttClient.publish(topic, data)
 
 
 ##############################################################################
 #
-#	Utility functions
+# Utility functions
 #
 
-def idToMQTT(id:str) -> str:
-	"""	Convert a oneM2M ID to an MQTT compatible path element.
-	"""
-	return f'{id.lstrip("/").replace("/", ":")}'
+def idToMQTT(id: str) -> str:
+    """	Convert a oneM2M ID to an MQTT compatible path element.
+    """
+    return f'{id.lstrip("/").replace("/", ":")}'
 
 
-def idToMQTTClientID(id:str, isCSE:bool=True) -> str:
-	"""	Convert a oneM2M ID to an MQTT client ID.
-	"""
-	return f'{"C::" if isCSE else "A::"}{id.lstrip("/")}'
+def idToMQTTClientID(id: str, isCSE: bool = True) -> str:
+    """	Convert a oneM2M ID to an MQTT client ID.
+    """
+    return f'{"C::" if isCSE else "A::"}{id.lstrip("/")}'
 
-def mqttToId(mqttId:str, isCSE:bool=True) -> Tuple[str, bool]:
-	"""	Convert an MQTT compatible path element to an ID.
-	"""
-	if mqttId.startswith('A:'):
-		isCSE = False
-	elif mqttId.startswith('C:'):
-		isCSE = True
-	else:
-		return None, False
-	return mqttId[2:].replace(':', '/'), isCSE
+
+def mqttToId(mqttId: str, isCSE: bool = True) -> Tuple[str, bool]:
+    """	Convert an MQTT compatible path element to an ID.
+    """
+    if mqttId.startswith('A:'):
+        isCSE = False
+    elif mqttId.startswith('C:'):
+        isCSE = True
+    else:
+        return None, False
+    return mqttId[2:].replace(':', '/'), isCSE
 
 
 # Type for an MQTT Callback

--- a/acme/helpers/MQTTConnection.py
+++ b/acme/helpers/MQTTConnection.py
@@ -22,61 +22,61 @@ import paho.mqtt.client as mqtt
 
 @dataclass
 class MQTTTopic:
-    """	Structure that represents a subscribed-to topic.
-    """
-    topic: str = None
-    mid: int = None
-    isSubscribed: bool = False
-    callback: MQTTCallback = None
-    callbackArgs: dict = None
+	"""	Structure that represents a subscribed-to topic.
+	"""
+	topic: str = None
+	mid: int = None
+	isSubscribed: bool = False
+	callback: MQTTCallback = None
+	callbackArgs: dict = None
 
 
 class MQTTHandler(object):
-    """	This base class defines the interface for an MQTT handler class.
-            The abstract methods defined here must be implemented by the implementing class.
+	"""	This base class defines the interface for an MQTT handler class.
+			The abstract methods defined here must be implemented by the implementing class.
 
-            The implementing class acts as a handler for various callbacks when dealing with
-            the MQTT handler. To receive messages a client implementation must register topics
-            and the callbacks for them in the `onConnect()` method.
-    """
+			The implementing class acts as a handler for various callbacks when dealing with
+			the MQTT handler. To receive messages a client implementation must register topics
+			and the callbacks for them in the `onConnect()` method.
+	"""
 
-    def onConnect(self, connection: MQTTConnection) -> bool:
-        """	This method is called after the MQTT client connected to the MQTT broker.
-                Usually, an MQTT client should subscribe to topics and register the callback
-                methods here.
-        """
-        return True
+	def onConnect(self, connection: MQTTConnection) -> bool:
+		"""	This method is called after the MQTT client connected to the MQTT broker.
+				Usually, an MQTT client should subscribe to topics and register the callback
+				methods here.
+		"""
+		return True
 
-    def onDisconnect(self, connection: MQTTConnection) -> bool:
-        """	This method is called after the MQTT client disconnected from the MQTT broker.
-        """
-        return True
+	def onDisconnect(self, connection: MQTTConnection) -> bool:
+		"""	This method is called after the MQTT client disconnected from the MQTT broker.
+		"""
+		return True
 
-    def onSubscribed(self, connection: MQTTConnection, topic: str) -> bool:
-        """	This method is called after the MQTT client successfully subsribed to a topic.
-        """
-        connection.subscribedCount += 1
-        return True
+	def onSubscribed(self, connection: MQTTConnection, topic: str) -> bool:
+		"""	This method is called after the MQTT client successfully subsribed to a topic.
+		"""
+		connection.subscribedCount += 1
+		return True
 
-    def onUnsubscribed(self, connection: MQTTConnection, topic: str) -> bool:
-        """	This method is called after the MQTT client successfully unsubsribed from a topic.
-        """
-        connection.subscribedCount -= 1
-        return True
+	def onUnsubscribed(self, connection: MQTTConnection, topic: str) -> bool:
+		"""	This method is called after the MQTT client successfully unsubsribed from a topic.
+		"""
+		connection.subscribedCount -= 1
+		return True
 
-    def onError(self, connection: MQTTConnection, rc: int) -> bool:
-        """	This method is called when receiving an error when communicating with the MQTT broker.
-        """
-        return True
+	def onError(self, connection: MQTTConnection, rc: int) -> bool:
+		"""	This method is called when receiving an error when communicating with the MQTT broker.
+		"""
+		return True
 
-    def logging(self, connection: MQTTConnection, level: int, message: str) -> bool:
-        """	This method is called when a log message should be handled.
-        """
-        return True
+	def logging(self, connection: MQTTConnection, level: int, message: str) -> bool:
+		"""	This method is called when a log message should be handled.
+		"""
+		return True
 
-    def onShutdown(self, connection: MQTTConnection) -> None:
-        """	This method is called after the ```connection``` was shut down.
-        """
+	def onShutdown(self, connection: MQTTConnection) -> None:
+		"""	This method is called after the ```connection``` was shut down.
+		"""
 
 
 ##############################################################################
@@ -84,289 +84,274 @@ class MQTTHandler(object):
 
 class MQTTConnection(object):
 
-    #
-    # Runtime methods
-    #
+	#
+	# Runtime methods
+	#
 
-    def __init__(self, address: str, port: int = None, keepalive: int = 60, interface: str = '0.0.0.0',
-                 clientID: str = None, username: str = None, password: str = None,
-                 useTLS: bool = False, cafile: str = None, verifyCertificate: bool = False, certfile: str = None, keyfile: str = None,
-                 lowLevelLogging: bool = True,
-                 messageHandler: MQTTHandler = None
-                 ) -> None:
-        self.address = address
-        self.port = port if port else 4883 if useTLS else 1883
-        self.keepalive = keepalive
-        self.bindIF = interface
-        self.username: str = username
-        self.password: str = password
-        self.useTLS: bool = useTLS
-        self.verifyCertificate = verifyCertificate
-        self.caFile = cafile
-        # MIO_AID MQTTS Added 09.11.2022 START
-        self.mqttsCertfile = certfile
-        self.mqttsKeyfile = keyfile
-    # END
-        self.clientID = clientID
-        self.lowLevelLogging = lowLevelLogging
+	def __init__(self, address: str, port: int = None, keepalive: int = 60, interface: str = '0.0.0.0',
+				 clientID: str = None, username: str = None, password: str = None,
+				 useTLS: bool = False, cafile: str = None, verifyCertificate: bool = False, certfile: str = None, keyfile: str = None,
+				 lowLevelLogging: bool = True,
+				 messageHandler: MQTTHandler = None
+				 ) -> None:
+		self.address = address
+		self.port = port if port else 4883 if useTLS else 1883
+		self.keepalive = keepalive
+		self.bindIF = interface
+		self.username: str = username
+		self.password: str = password
+		self.useTLS: bool = useTLS
+		self.verifyCertificate = verifyCertificate
+		self.caFile = cafile
+		self.mqttsCertfile = certfile
+		self.mqttsKeyfile = keyfile
+		self.clientID = clientID
+		self.lowLevelLogging = lowLevelLogging
 
-        self.isStopped = True
-        self.isConnected = False
-        self.subscribedCount = 0
+		self.isStopped = True
+		self.isConnected = False
+		self.subscribedCount = 0
 
-        self.mqttClient: mqtt.Client = None
-        self.messageHandler: MQTTHandler = messageHandler
-        self.actor: BackgroundWorker = None
-        self.subscribedTopics: dict[str, MQTTTopic] = {}
+		self.mqttClient: mqtt.Client = None
+		self.messageHandler: MQTTHandler = messageHandler
+		self.actor: BackgroundWorker = None
+		self.subscribedTopics: dict[str, MQTTTopic] = {}
 
-    def shutdown(self) -> bool:
-        """	Shutting down the MQTT client.
-        """
+	def shutdown(self) -> bool:
+		"""	Shutting down the MQTT client.
+		"""
 
-        self.isStopped = True
-        if self.mqttClient:
-            # if self.mqttClient and self.isConnected:
-            # Unsubscribe from all topics
-            for t in list(self.subscribedTopics.values()):
-                self.unsubscribeTopic(t)
-            # wait a moment for all unsubscribe ACKs to arrive
-            while len(self.subscribedTopics) > 0:
-                time.sleep(0.1)
-            # Then disconnect. The actor is stoped implicitly
-            self.mqttClient.disconnect()
-            self.actor = None
+		self.isStopped = True
+		if self.mqttClient:
+			# if self.mqttClient and self.isConnected:
+			# Unsubscribe from all topics
+			for t in list(self.subscribedTopics.values()):
+				self.unsubscribeTopic(t)
+			# wait a moment for all unsubscribe ACKs to arrive
+			while len(self.subscribedTopics) > 0:
+				time.sleep(0.1)
+			# Then disconnect. The actor is stoped implicitly
+			self.mqttClient.disconnect()
+			self.actor = None
 
-        self.messageHandler and self.messageHandler.logging(
-            self.mqttClient, logging.INFO, 'MQTT client shut down')
-        return True
+		self.messageHandler and self.messageHandler.logging(
+			self.mqttClient, logging.INFO, 'MQTT client shut down')
+		return True
 
-    # def ssl_alpn(self) -> ssl.SSLContext:
-    #     try:
-    #         #debug print opnessl version
-    #         ssl_context = ssl.create_default_context()
-    #         ssl_context.load_verify_locations(cafile=self.caFile)
-    #         ssl_context.load_cert_chain(certfile=self.mqttsCertfile, keyfile=self.mqttsKeyfile)
+	def run(self) -> None:
+		"""	Initialize and run the MQTT client as a BackgroundWorker/Actor.
+		"""
+		self.messageHandler and self.messageHandler.logging(
+			self.mqttClient, logging.DEBUG, f'MQTT: client name: {self.clientID}')
+		# clean_session=False is defined by TS-0010
+		self.mqttClient = mqtt.Client(
+			client_id=self.clientID, clean_session=False if self.clientID else True)
 
-    #         return  ssl_context
-    #     except Exception as e:
-    #         print("exception ssl_alpn()")
-    #         raise e
+		# Enable SSL
+		if self.useTLS:
+			self.mqttClient.tls_set(ca_certs=self.caFile, certfile=self.mqttsCertfile, keyfile=self.mqttsKeyfile, cert_reqs=ssl.CERT_REQUIRED, tls_version=ssl.PROTOCOL_TLS, ciphers=None)
 
-    def run(self) -> None:
-        """	Initialize and run the MQTT client as a BackgroundWorker/Actor.
-        """
-        self.messageHandler and self.messageHandler.logging(
-            self.mqttClient, logging.DEBUG, f'MQTT: client name: {self.clientID}')
-        # clean_session=False is defined by TS-0010
-        self.mqttClient = mqtt.Client(
-            client_id=self.clientID, clean_session=False if self.clientID else True)
+		# Set username/password
+		if self.username and self.password:
+			self.mqttClient.username_pw_set(self.username, self.password)
 
-        # Enable SSL
-        if self.useTLS:
-            self.mqttClient.tls_set(ca_certs=self.caFile, certfile=self.mqttsCertfile, keyfile=self.mqttsKeyfile, cert_reqs=ssl.CERT_REQUIRED, tls_version=ssl.PROTOCOL_TLS, ciphers=None)
-            #self.mqttClient.tls_set(ca_certs=self.caFile, cert_reqs=ssl.CERT_REQUIRED if self.verifyCertificate else ssl.CERT_NONE)
+		self.mqttClient.on_connect = self._onConnect
+		self.mqttClient.on_disconnect = self._onDisconnect
+		self.mqttClient.on_log = self._onLog
+		self.mqttClient.on_subscribe = self._onSubscribe
+		self.mqttClient.on_unsubscribe = self._onUnsubscribe
+		self.mqttClient.on_message = self._onMessage
 
-            # Set username/password
-        if self.username and self.password:
-            self.mqttClient.username_pw_set(self.username, self.password)
+		try:
+			self.messageHandler and self.messageHandler.logging(
+				self.mqttClient, logging.DEBUG, f'MQTT: connecting to host:{self.address}, port:{self.port}, keepalive: {self.keepalive}, bind: {self.bindIF}')
+			self.mqttClient.connect(
+				host=self.address, port=self.port, keepalive=self.keepalive, bind_address=self.bindIF)
+		except Exception as e:
+			if self.messageHandler:
+				self.messageHandler.logging(
+					self.mqttClient, logging.ERROR, f'MQTT: cannot connect to broker: {e}')
+				self.messageHandler.onError(self, -1)
 
-        self.mqttClient.on_connect = self._onConnect
-        self.mqttClient.on_disconnect = self._onDisconnect
-        self.mqttClient.on_log = self._onLog
-        self.mqttClient.on_subscribe = self._onSubscribe
-        self.mqttClient.on_unsubscribe = self._onUnsubscribe
-        self.mqttClient.on_message = self._onMessage
+		# Actually start the actor to run the MQTT client as a thread
+		self.actor = BackgroundWorkerPool.newActor(
+			self._mqttActor, name='MQTTClient').start()
 
-        try:
-            self.messageHandler and self.messageHandler.logging(
-                self.mqttClient, logging.DEBUG, f'MQTT: connecting to host:{self.address}, port:{self.port}, keepalive: {self.keepalive}, bind: {self.bindIF}')
-            self.mqttClient.connect(
-                host=self.address, port=self.port, keepalive=self.keepalive, bind_address=self.bindIF)
-        except Exception as e:
-            if self.messageHandler:
-                self.messageHandler.logging(
-                    self.mqttClient, logging.ERROR, f'MQTT: cannot connect to broker: {e}')
-                self.messageHandler.onError(self, -1)
+	def _mqttActor(self) -> bool:
+		"""	Backgroundworker callback to run the actuall MQTT loop.
+		"""
+		self.isStopped = False
+		self.messageHandler and self.messageHandler.logging(
+			self.mqttClient, logging.INFO, 'MQTT: client started')
+		while not self.isStopped:
+			self.mqttClient.loop_forever()  # Will return when disconnect() is called
+		if self.messageHandler:
+			self.messageHandler.onShutdown(self)
+		return True
 
-        # Actually start the actor to run the MQTT client as a thread
-        self.actor = BackgroundWorkerPool.newActor(
-            self._mqttActor, name='MQTTClient').start()
+	#
+	# MQTT/paho callbacks
+	#
 
-    def _mqttActor(self) -> bool:
-        """	Backgroundworker callback to run the actuall MQTT loop.
-        """
-        self.isStopped = False
-        self.messageHandler and self.messageHandler.logging(
-            self.mqttClient, logging.INFO, 'MQTT: client started')
-        while not self.isStopped:
-            self.mqttClient.loop_forever()  # Will return when disconnect() is called
-        if self.messageHandler:
-            self.messageHandler.onShutdown(self)
-        return True
+	def _onConnect(self, client: mqtt.Client, userdata: Any, flags: dict, rc: int) -> None:
+		"""	Callback when the MQTT client connected to the broker.
+		"""
+		self.messageHandler and self.messageHandler.logging(
+			self, logging.DEBUG, f'MQTT: Connected with result code: {rc} ({mqtt.error_string(rc)})')
+		if rc == 0:
+			self.isConnected = True
+			self.messageHandler and self.messageHandler.onConnect(self)
+		else:
+			self.isConnected = False
+			if self.messageHandler:
+				self.messageHandler.logging(
+					self, logging.ERROR, f'MQTT: Cannot connect to broker. Result code: {rc} ({mqtt.error_string(rc)})')
+				self.messageHandler.onError(self, rc)
 
-    #
-    # MQTT/paho callbacks
-    #
+	def _onDisconnect(self, client: mqtt.Client, userdata: Any, rc: int) -> None:
+		"""	Callback when the MQTT client disconnected from the broker.
+		"""
+		self.messageHandler and self.messageHandler.logging(
+			self, logging.DEBUG, f'MQTT: Disconnected with result code: {rc} ({mqtt.error_string(rc)})')
+		self.subscribedTopics.clear()
+		if rc == 0:
+			self.isConnected = False
+			self.messageHandler and self.messageHandler.onDisconnect(self)
+		elif rc == 7:
+			self.isConnected = False
+			self.messageHandler.logging(
+				self, logging.ERROR, f'MQTT: Cannot disconnect from broker. Result code: {rc} ({mqtt.error_string(rc)})')
+			self.messageHandler.logging(
+				self, logging.ERROR, f'MQTT: Did another client connected with the same ID ({self.clientID})?')
+			self.messageHandler and self.messageHandler.onDisconnect(self)
+		else:
+			self.isConnected = False
+			if self.messageHandler:
+				self.messageHandler.logging(
+					self, logging.ERROR, f'MQTT: Cannot disconnect from broker. Result code: {rc} ({mqtt.error_string(rc)})')
+				self.messageHandler.onDisconnect(self)
+				self.messageHandler.onError(self, rc)
 
-    def _onConnect(self, client: mqtt.Client, userdata: Any, flags: dict, rc: int) -> None:
-        """	Callback when the MQTT client connected to the broker.
-        """
-        self.messageHandler and self.messageHandler.logging(
-            self, logging.DEBUG, f'MQTT: Connected with result code: {rc} ({mqtt.error_string(rc)})')
-        if rc == 0:
-            self.isConnected = True
-            self.messageHandler and self.messageHandler.onConnect(self)
-        else:
-            self.isConnected = False
-            if self.messageHandler:
-                self.messageHandler.logging(
-                    self, logging.ERROR, f'MQTT: Cannot connect to broker. Result code: {rc} ({mqtt.error_string(rc)})')
-                self.messageHandler.onError(self, rc)
+	def _onLog(self, client: mqtt.Client, userdata: Any, level: int, buf: str) -> None:
+		"""	Mapping of the paho MQTT client's log to the logging system. Also handles different log-level scheme.
+		"""
+		self.lowLevelLogging and self.messageHandler and self.messageHandler.logging(
+			self, mqtt.LOGGING_LEVEL[level], f'MQTT: {buf}')
 
-    def _onDisconnect(self, client: mqtt.Client, userdata: Any, rc: int) -> None:
-        """	Callback when the MQTT client disconnected from the broker.
-        """
-        self.messageHandler and self.messageHandler.logging(
-            self, logging.DEBUG, f'MQTT: Disconnected with result code: {rc} ({mqtt.error_string(rc)})')
-        self.subscribedTopics.clear()
-        if rc == 0:
-            self.isConnected = False
-            self.messageHandler and self.messageHandler.onDisconnect(self)
-        elif rc == 7:
-            self.isConnected = False
-            self.messageHandler.logging(
-                self, logging.ERROR, f'MQTT: Cannot disconnect from broker. Result code: {rc} ({mqtt.error_string(rc)})')
-            self.messageHandler.logging(
-                self, logging.ERROR, f'MQTT: Did another client connected with the same ID ({self.clientID})?')
-            self.messageHandler and self.messageHandler.onDisconnect(self)
-        else:
-            self.isConnected = False
-            if self.messageHandler:
-                self.messageHandler.logging(
-                    self, logging.ERROR, f'MQTT: Cannot disconnect from broker. Result code: {rc} ({mqtt.error_string(rc)})')
-                self.messageHandler.onDisconnect(self)
-                self.messageHandler.onError(self, rc)
+	def _onSubscribe(self, client: mqtt.Client, userdata: Any, mid: int, granted_qos: int) -> None:
+		# TODO doc, error check when not connected, not subscribed
+		for t in self.subscribedTopics.values():
+			if t.mid == mid:
+				t.isSubscribed = True
+				self.messageHandler and self.messageHandler.onSubscribed(
+					self, t.topic)
+				break
 
-    def _onLog(self, client: mqtt.Client, userdata: Any, level: int, buf: str) -> None:
-        """	Mapping of the paho MQTT client's log to the logging system. Also handles different log-level scheme.
-        """
-        self.lowLevelLogging and self.messageHandler and self.messageHandler.logging(
-            self, mqtt.LOGGING_LEVEL[level], f'MQTT: {buf}')
+	def _onUnsubscribe(self, client: mqtt.Client, userdata: Any, mid: int) -> None:
+		# TODO doc, error check when not connected, not subscribed
+		"""	Callback when the client successfulle unsubscribed from a topic. The topic
+				is also removed from the internal list.
+		"""
+		for t in self.subscribedTopics.values():
+			if t.mid == mid:
+				del self.subscribedTopics[t.topic]
+				self.messageHandler and self.messageHandler.onUnsubscribed(
+					self, t.topic)
+				break
 
-    def _onSubscribe(self, client: mqtt.Client, userdata: Any, mid: int, granted_qos: int) -> None:
-        # TODO doc, error check when not connected, not subscribed
-        for t in self.subscribedTopics.values():
-            if t.mid == mid:
-                t.isSubscribed = True
-                self.messageHandler and self.messageHandler.onSubscribed(
-                    self, t.topic)
-                break
+	def _onMessage(self, client: mqtt.Client, userdata: Any, message: mqtt.MQTTMessage) -> None:
+		"""	Handle a received message. Forward it to the apropriate handler callback (in a Thread)
+		"""
+		self.lowLevelLogging and self.messageHandler and self.messageHandler.logging(
+			self, logging.DEBUG, f'MQTT: received topic:{message.topic}, payload:{message.payload}')
+		for t in self.subscribedTopics.keys():
+			if simpleMatch(message.topic, t, star='#'):
+				if (topic := self.subscribedTopics[t]).callback:
+					# Run actual request handling in a thread
+					# For some reasons mid is not initialized in the on on_message callback, so we use the timestamp for the actor name
+					BackgroundWorkerPool.newActor(topic.callback, name=f'mid_{message.timestamp}').start(connection=self,
+																										 topic=message.topic,
+																										 data=message.payload,
+																										 **topic.callbackArgs)
+					break  # break at first occurence
 
-    def _onUnsubscribe(self, client: mqtt.Client, userdata: Any, mid: int) -> None:
-        # TODO doc, error check when not connected, not subscribed
-        """	Callback when the client successfulle unsubscribed from a topic. The topic
-                is also removed from the internal list.
-        """
-        for t in self.subscribedTopics.values():
-            if t.mid == mid:
-                del self.subscribedTopics[t.topic]
-                self.messageHandler and self.messageHandler.onUnsubscribed(
-                    self, t.topic)
-                break
+	#
+	# MQTT messaging methods
+	#
 
-    def _onMessage(self, client: mqtt.Client, userdata: Any, message: mqtt.MQTTMessage) -> None:
-        """	Handle a received message. Forward it to the apropriate handler callback (in a Thread)
-        """
-        self.lowLevelLogging and self.messageHandler and self.messageHandler.logging(
-            self, logging.DEBUG, f'MQTT: received topic:{message.topic}, payload:{message.payload}')
-        for t in self.subscribedTopics.keys():
-            if simpleMatch(message.topic, t, star='#'):
-                if (topic := self.subscribedTopics[t]).callback:
-                    # Run actual request handling in a thread
-                    # For some reasons mid is not initialized in the on on_message callback, so we use the timestamp for the actor name
-                    BackgroundWorkerPool.newActor(topic.callback, name=f'mid_{message.timestamp}').start(connection=self,
-                                                                                                         topic=message.topic,
-                                                                                                         data=message.payload,
-                                                                                                         **topic.callbackArgs)
-                    break  # break at first occurence
+	def subscribeTopic(self, topic: str | list[str], callback: MQTTCallback = None, **kwargs: Any) -> None:
+		"""	Add one or more MQTT topics to subscribe to. Add the topic(s) afterwards
+				to the list of subscribed-to topics.
+		"""
+		def _subscribe(topic: str) -> None:
+			"""	Handle subscription of a single topic.
+			"""
+			if topic in self.subscribedTopics:
+				self.messageHandler and self.messageHandler.logging(
+					self.mqttClient, logging.WARNING, f'MQTT: topic already subscribed: {topic}')
+				return
+			if (r := self.mqttClient.subscribe(topic))[0] == 0:
+				t = MQTTTopic(
+					topic=topic, mid=r[1], callback=callback, callbackArgs=kwargs)
+				self.subscribedTopics[topic] = t
+			else:
+				self.messageHandler and self.messageHandler.logging(
+					self.mqttClient, logging.ERROR, f'MQTT: cannot subscribe: {r[0]}')
 
-    #
-    # MQTT messaging methods
-    #
+		if not self.mqttClient or not self.isConnected:
+			self.messageHandler and self.messageHandler.logging(
+				self.mqttClient, logging.ERROR, 'MQTT: Client missing or not initialized')
+			return
 
-    def subscribeTopic(self, topic: str | list[str], callback: MQTTCallback = None, **kwargs: Any) -> None:
-        """	Add one or more MQTT topics to subscribe to. Add the topic(s) afterwards
-                to the list of subscribed-to topics.
-        """
-        def _subscribe(topic: str) -> None:
-            """	Handle subscription of a single topic.
-            """
-            if topic in self.subscribedTopics:
-                self.messageHandler and self.messageHandler.logging(
-                    self.mqttClient, logging.WARNING, f'MQTT: topic already subscribed: {topic}')
-                return
-            if (r := self.mqttClient.subscribe(topic))[0] == 0:
-                t = MQTTTopic(
-                    topic=topic, mid=r[1], callback=callback, callbackArgs=kwargs)
-                self.subscribedTopics[topic] = t
-            else:
-                self.messageHandler and self.messageHandler.logging(
-                    self.mqttClient, logging.ERROR, f'MQTT: cannot subscribe: {r[0]}')
+		# either subscribe a list of topics or a single topic
+		list(map(_subscribe, topic if isinstance(topic, list) else [topic]))
 
-        if not self.mqttClient or not self.isConnected:
-            self.messageHandler and self.messageHandler.logging(
-                self.mqttClient, logging.ERROR, 'MQTT: Client missing or not initialized')
-            return
+	def unsubscribeTopic(self, topic: str | MQTTTopic) -> None:
+		"""	Unsubscribe from a topic. `topic` is either an MQTTTopic structure with
+				a previously subscribed to topic, or a topic name, in which case
+				it is searched for in the list of MQTTTopics.
+		"""
+		if isinstance(topic, MQTTTopic):
+			if topic.topic not in self.subscribedTopics:
+				self.messageHandler and self.messageHandler.logging(
+					self.mqttClient, logging.WARNING, f'MQTT: unknown topic: {topic.topic}')
+				return
+			if (r := self.mqttClient.unsubscribe(topic.topic))[0] == 0:
+				topic.mid = r[1]
+			else:
+				self.messageHandler and self.messageHandler.logging(
+					self.mqttClient, logging.ERROR, f'MQTT: cannot unsubscribe: {r[0]}')
+				return
 
-        # either subscribe a list of topics or a single topic
-        list(map(_subscribe, topic if isinstance(topic, list) else [topic]))
+		else:  # if topic is just the name we need to subscribe to
+			if topic not in self.subscribedTopics:
+				self.messageHandler and self.messageHandler.logging(
+					self.mqttClient, logging.WARNING, f'MQTT: unknown topic: {topic}')
+				return
+			t = self.subscribedTopics[topic]
+			if t.isSubscribed:
+				if (r := self.mqttClient.unsubscribe(t.topic))[0] == 0:
+					t.mid = r[1]
+				else:
+					self.messageHandler and self.messageHandler.logging(
+						self.mqttClient, logging.ERROR, f'MQTT: cannot unsubscribe: {r[0]}')
+					return
+			else:
+				self.messageHandler and self.messageHandler.logging(
+					self.mqttClient, logging.WARNING, f'MQTT: topic not subscribed: {topic}')
 
-    def unsubscribeTopic(self, topic: str | MQTTTopic) -> None:
-        """	Unsubscribe from a topic. `topic` is either an MQTTTopic structure with
-                a previously subscribed to topic, or a topic name, in which case
-                it is searched for in the list of MQTTTopics.
-        """
-        if isinstance(topic, MQTTTopic):
-            if topic.topic not in self.subscribedTopics:
-                self.messageHandler and self.messageHandler.logging(
-                    self.mqttClient, logging.WARNING, f'MQTT: unknown topic: {topic.topic}')
-                return
-            if (r := self.mqttClient.unsubscribe(topic.topic))[0] == 0:
-                topic.mid = r[1]
-            else:
-                self.messageHandler and self.messageHandler.logging(
-                    self.mqttClient, logging.ERROR, f'MQTT: cannot unsubscribe: {r[0]}')
-                return
+		# topic is removed in _onUnsubscribe() callback
 
-        else:  # if topic is just the name we need to subscribe to
-            if topic not in self.subscribedTopics:
-                self.messageHandler and self.messageHandler.logging(
-                    self.mqttClient, logging.WARNING, f'MQTT: unknown topic: {topic}')
-                return
-            t = self.subscribedTopics[topic]
-            if t.isSubscribed:
-                if (r := self.mqttClient.unsubscribe(t.topic))[0] == 0:
-                    t.mid = r[1]
-                else:
-                    self.messageHandler and self.messageHandler.logging(
-                        self.mqttClient, logging.ERROR, f'MQTT: cannot unsubscribe: {r[0]}')
-                    return
-            else:
-                self.messageHandler and self.messageHandler.logging(
-                    self.mqttClient, logging.WARNING, f'MQTT: topic not subscribed: {topic}')
+	def isFullySubscribed(self) -> bool:
+		"""	Check whether the number managed subscriptions matches the number of
+				currently subscribed-to topics.
+		"""
+		return self.subscribedCount == len(self.subscribedTopics)
 
-        # topic is removed in _onUnsubscribe() callback
-
-    def isFullySubscribed(self) -> bool:
-        """	Check whether the number managed subscriptions matches the number of
-                currently subscribed-to topics.
-        """
-        return self.subscribedCount == len(self.subscribedTopics)
-
-    def publish(self, topic: str, data: bytes) -> None:
-        """	Publish the message `data` with the topic `topic` with the MQTT broker.
-        """
-        self.mqttClient.publish(topic, data)
+	def publish(self, topic: str, data: bytes) -> None:
+		"""	Publish the message `data` with the topic `topic` with the MQTT broker.
+		"""
+		self.mqttClient.publish(topic, data)
 
 
 ##############################################################################
@@ -375,27 +360,27 @@ class MQTTConnection(object):
 #
 
 def idToMQTT(id: str) -> str:
-    """	Convert a oneM2M ID to an MQTT compatible path element.
-    """
-    return f'{id.lstrip("/").replace("/", ":")}'
+	"""	Convert a oneM2M ID to an MQTT compatible path element.
+	"""
+	return f'{id.lstrip("/").replace("/", ":")}'
 
 
 def idToMQTTClientID(id: str, isCSE: bool = True) -> str:
-    """	Convert a oneM2M ID to an MQTT client ID.
-    """
-    return f'{"C::" if isCSE else "A::"}{id.lstrip("/")}'
+	"""	Convert a oneM2M ID to an MQTT client ID.
+	"""
+	return f'{"C::" if isCSE else "A::"}{id.lstrip("/")}'
 
 
 def mqttToId(mqttId: str, isCSE: bool = True) -> Tuple[str, bool]:
-    """	Convert an MQTT compatible path element to an ID.
-    """
-    if mqttId.startswith('A:'):
-        isCSE = False
-    elif mqttId.startswith('C:'):
-        isCSE = True
-    else:
-        return None, False
-    return mqttId[2:].replace(':', '/'), isCSE
+	"""	Convert an MQTT compatible path element to an ID.
+	"""
+	if mqttId.startswith('A:'):
+		isCSE = False
+	elif mqttId.startswith('C:'):
+		isCSE = True
+	else:
+		return None, False
+	return mqttId[2:].replace(':', '/'), isCSE
 
 
 # Type for an MQTT Callback

--- a/tools/notificationServer/README.md
+++ b/tools/notificationServer/README.md
@@ -29,14 +29,18 @@ In additions, you can provide additional command line arguments:
 | --port &lt;port>                           | Specify the server port (default: 9999).                             |
 | --http, --https                            | Run as http (default) or as https server.                            |
 | --certfile &lt;certfile>                   | Specify the certificate file (mandatory for https).                  |
-| --keyfile &lt;>keyfile>                    | Specify the key file (mandatory for https).                          |
+| --keyfile &lt;keyfile>                     | Specify the key file (mandatory for https).                          |
 | --mqtt                                     | Additionally enable MQTT for notifications                           |
-| --mqtt-address &lt;>host>                  | MQTT broker address (default: localhost)                             |
-| --mqtt-port &lt;>port>                     | MQTT broker port (default: 1883)                                     |
-| --mqtt-topic &lt;>topic> [&lt;>topic> ...] | MQTT topic list to subscribe to (default: ['/oneM2M/req/id-in/+/#']) |
-| --mqtt-username &lt;>username>             | MQTT username (default: None)                                        |
-| --mqtt-password &lt;>password>             | MQTT password (default: None)                                        |
+| --mqtt-address &lt;host>                   | MQTT broker address (default: localhost)                             |
+| --mqtt-port &lt;port>                      | MQTT broker port (default: 1883)                                     |
+| --mqtt-topic &lt;topic> [&lt;topic> ...]   | MQTT topic list to subscribe to (default: ['/oneM2M/req/id-in/+/#']) |
+| --mqtt-username &lt;username>              | MQTT username (default: None)                                        |
+| --mqtt-password &lt;password>              | MQTT password (default: None)                                        |
 | --mqtt-logging                             | MQTT enable logging (default: disabled)                              |
+| --mqtt-useTLS								 | MQTT enable TLS (default: disabled)									|
+| --mqtt-caFile	&lt;cafile>				 	 | Specify the CA certificate file (mandatory for MQTTS)				|
+| --mqtt-certfile &lt;certfile>				 | Specify the certificate file (mandatory for MQTTS)					|
+| --mqtt-keyfile &lt;keyfile>				 | Specify the key file (mandatory for MQTTS)							|
 | --fail-verification                        | Fail all verification requests with "no privileges" (default: False) |
 
 
@@ -45,6 +49,6 @@ The following command starts the NotificationServer with MQTT support enabled. I
 and would listen to the topics "/oneM2M/req/id-in/+/#" and "/oneM2M/req/id-mn/+/#". In addition logging extra information about the MQTT communication to the console
 is enabled.
 
-	python3 notificationServer.py --mqtt --mqtt-address mqttAddress --mqtt-username mqttUser --mqtt-password mqttPassword --mqtt-topic /oneM2M/req/id-in/+/# /oneM2M/req/id-mn/+/# --mqtt-logging
+	python3 notificationServer.py --mqtt --mqtt-address mqttAddress --mqtt-username mqttUser --mqtt-password mqttPassword --mqtt-useTLS --mqtt-caFile caFile --mqtt-certfile certFile -- mqtt-keyfile keyFile --mqtt-topic /oneM2M/req/id-in/+/# /oneM2M/req/id-mn/+/# --mqtt-logging
 
 [← README](../../README.md) 

--- a/tools/notificationServer/notificationServer.py
+++ b/tools/notificationServer/notificationServer.py
@@ -1,11 +1,11 @@
 #
-#	notificationServer.py
+# notificationServer.py
 #
-#	(c) 2020 by Andreas Kraft
-#	License: BSD 3-Clause License. See the LICENSE file for further details.
+# (c) 2020 by Andreas Kraft
+# License: BSD 3-Clause License. See the LICENSE file for further details.
 #
-#	Simple base implementation of a notification server to handle notifications 
-#	from a CSE.
+# Simple base implementation of a notification server to handle notifications
+# from a CSE.
 #
 
 from __future__ import annotations
@@ -18,6 +18,7 @@ import cbor2
 from rich.console import Console
 from rich.syntax import Syntax
 
+import paho.mqtt.client as mqtt
 import pathlib, os
 parent = pathlib.Path(os.path.abspath(os.path.dirname(__file__))).parent.parent
 sys.path.append(f'{parent}')
@@ -28,305 +29,339 @@ from acme.etc.DateUtils import getResourceDate
 from acme.etc.Types import ContentSerializationType
 from acme.etc.Constants import Constants as C
 
+import ssl
+
 ##############################################################################
 #
-#	HTTP Server
+# HTTP Server
 #
 
-port = 9999	# Change this variable to specify another port.
+port = 9999  # Change this variable to specify another port.
 messageColor = 'spring_green2'
 errorColor = 'red'
 
 failVerification = False
 
+
 class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
 
-	def do_GET(self) -> None:
-		"""	Just provide a simple web page.
-		"""
-		self.send_response(200)
-		self.send_header('Content-type', 'text/html')
-		self.end_headers()
-		self.wfile.write(bytes("<html><head><title>[ACME] Notification Server</title></head><body>This server doesn't provide a web page.</body></html>","utf-8")) 
+    def do_GET(self) -> None:
+        """	Just provide a simple web page.
+        """
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+        self.wfile.write(bytes(
+            "<html><head><title>[ACME] Notification Server</title></head><body>This server doesn't provide a web page.</body></html>", "utf-8"))
 
+    def do_POST(self) -> None:
+        """	Handle notification.
+        """
 
-	def do_POST(self) -> None:
-		"""	Handle notification.
-		"""
+        _responseHeaders: list = []
 
-		_responseHeaders:list = []
+        # Get headers and content data
+        length = int(self.headers['Content-Length'])
+        contentType = self.headers['Content-Type']
+        requestID = self.headers['X-M2M-RI']
+        post_data = self.rfile.read(length)
 
-		# Get headers and content data
-		length = int(self.headers['Content-Length'])
-		contentType = self.headers['Content-Type']
-		requestID = self.headers['X-M2M-RI']
-		post_data = self.rfile.read(length)
+        # Construct return header
+        # Always acknowledge the verification requests
+        self.send_response(200)
+        self.send_header(
+            'X-M2M-RSC', '2000' if not failVerification else '4101')
+        self.send_header('X-M2M-RI', requestID)
+        _responseHeaders = self._headers_buffer  # type:ignore [attr-defined]
+        self.end_headers()
 
-		# Construct return header
-		# Always acknowledge the verification requests
-		self.send_response(200)
-		self.send_header('X-M2M-RSC', '2000' if not failVerification else '4101')
-		self.send_header('X-M2M-RI', requestID)
-		_responseHeaders = self._headers_buffer	# type:ignore [attr-defined]
-		self.end_headers()
+        # Print the content data
+        console.print(f'[{messageColor}]### Notification (http)')
+        console.print(self.headers, highlight=False)
 
+        # Print JSON
+        if contentType in ['application/json', 'application/vnd.onem2m-res+json']:
+            console.print(Syntax(json.dumps(json.loads(post_data.decode('utf-8')), indent=4),
+                                 'json',
+                                 theme='monokai',
+                                 line_numbers=False))
 
-		
-		# Print the content data
-		console.print(f'[{messageColor}]### Notification (http)')
-		console.print(self.headers, highlight = False)
+        # Print CBOR
+        elif contentType in ['application/cbor', 'application/vnd.onem2m-res+cbor']:
+            console.print('[dim]Content as Hexdump:\n')
+            console.print(toHex(post_data), highlight=False)
+            console.print('\n[dim]Content as JSON:\n')
+            console.print(Syntax(json.dumps(cbor2.loads(post_data), indent=4),
+                                 'json',
+                                 theme='monokai',
+                                 line_numbers=False))
 
-		# Print JSON
-		if contentType in [ 'application/json', 'application/vnd.onem2m-res+json' ]:
-			console.print(Syntax(json.dumps(json.loads(post_data.decode('utf-8')), indent=4),
-							 'json', 
-							 theme='monokai',
-							 line_numbers=False))
-		
-		# Print CBOR
-		elif contentType in [ 'application/cbor', 'application/vnd.onem2m-res+cbor' ]:
-			console.print('[dim]Content as Hexdump:\n')
-			console.print(toHex(post_data), highlight=False)
-			console.print('\n[dim]Content as JSON:\n')
-			console.print(Syntax(json.dumps(cbor2.loads(post_data), indent=4),
-							 'json', 
-							 theme='monokai',
-							 line_numbers=False))		
+        # Print other binary content
+        else:
+            console.print(toHex(post_data), highlight=False)
 
-		# Print other binary content
-		else:
-			console.print(toHex(post_data), highlight=False)
-		
-		# Print HTTP Response
-		# This looks a it more complicated but is necessary to render nicely in Jupyter
-		console.print(f'[{messageColor}]### Notification Response (http)')
-		console.print(email.parser.Parser(_class = HTTPMessage).parsestr(b''.join(_responseHeaders).decode('iso-8859-1')), highlight = False)
+        # Print HTTP Response
+        # This looks a it more complicated but is necessary to render nicely in Jupyter
+        console.print(f'[{messageColor}]### Notification Response (http)')
+        console.print(email.parser.Parser(_class=HTTPMessage).parsestr(
+            b''.join(_responseHeaders).decode('iso-8859-1')), highlight=False)
 
-
-	def log_message(self, format:str, *args:int) -> None:
-		if (msg := format%args).startswith('"GET'):	return	# ignore GET log messages
-		console.print(f'[{messageColor} reverse]{msg}', highlight = False)
+    def log_message(self, format: str, *args: int) -> None:
+        if (msg := format % args).startswith('"GET'):
+            return  # ignore GET log messages
+        console.print(f'[{messageColor} reverse]{msg}', highlight=False)
 
 
 ##############################################################################
 #
-#	MQTT Client
+# MQTT Client
 #
 
-mqttNotificationTopic = [ '/oneM2M/req/id-in/+/#' ]
+mqttNotificationTopic = ['/oneM2M/req/id-in/+/#']
+
 
 class MQTTClientHandler(MQTTHandler):
 
-	def __init__(self, topic:str|list[str], enableLogging:bool) -> None:
-		super().__init__()
-		self.topic = topic
-		self.enableLogging = enableLogging
-		self.isShutdown = False
+    def __init__(self, topic: str | list[str], enableLogging: bool) -> None:
+        super().__init__()
+        self.topic = topic
+        self.enableLogging = enableLogging
+        self.isShutdown = False
 
+    def onConnect(self, connection: MQTTConnection) -> bool:
+        try:
+            # Subscribe to general requests
+            connection.subscribeTopic(self.topic, self._requestCB)
+        except Exception as e:
+            self.onError(connection, -1, f'MQTT {str(e)}')
+        return True
 
-	def onConnect(self, connection:MQTTConnection) -> bool:
-		try:
-			connection.subscribeTopic(self.topic, self._requestCB)					# Subscribe to general requests
-		except Exception as e:
-			self.onError(connection, -1, f'MQTT {str(e)}')
-		return True
+    def onError(self, connection: MQTTConnection, rc: int = -1, msg: str = None) -> bool:
+        if rc in [5]:		# authorization error
+            console.print(f'[{errorColor}]MQTT authorization error')
+            connection.shutdown()
+            console.print(f'[{messageColor}]MQTT client shutdown')
+        if rc == -1: 	# unknown. probably connection error?
+            if msg:
+                console.print(f'[{errorColor}]{msg}')
+            connection.shutdown()
+            console.print(f'[{messageColor}]MQTT client shutdown')
+        # ignore all others
+        return True
 
+    def logging(self, connection: MQTTConnection, level: int, message: str) -> bool:
+        if self.enableLogging:
+            console.print(f'{level}: {message}')
+        return True
 
-	def onError(self, connection:MQTTConnection, rc:int=-1, msg:str=None) -> bool:
-		if rc in [5]:		# authorization error
-			console.print(f'[{errorColor}]MQTT authorization error')
-			connection.shutdown()
-			console.print(f'[{messageColor}]MQTT client shutdown')
-		if rc == -1: 	# unknown. probably connection error?
-			if msg:
-				console.print(f'[{errorColor}]{msg}')
-			connection.shutdown()
-			console.print(f'[{messageColor}]MQTT client shutdown')
-		# ignore all others
-		return True
+    def onShutdown(self, connection: MQTTConnection) -> None:
+        if not self.isShutdown:
+            os.kill(os.getpid(), signal.SIGUSR1)
 
+    def _requestCB(self, connection: MQTTConnection, topic: str, data: bytes) -> None:
+        # TODO is it actually a notification? no -> do nothing, yes -> reply
 
-	def logging(self, connection:MQTTConnection, level:int, message:str) -> bool:
-		if self.enableLogging:
-			console.print(f'{level}: {message}')
-		return True
+        def _constructResponse(frm: str, to: str, jsn: dict) -> dict:
+            responseData = {'fr': frm,
+                            'to':	to,
+                            'rsc':	2000 if not failVerification else 4101,
+                            'ot':	getResourceDate()
+                            }
+            if (rqi := jsn.get('rqi')):
+                responseData['rqi'] = rqi
+            if (rvi := jsn.get('rvi')):
+                responseData['rvi'] = rvi
+            return responseData
 
+        console.print(f'[{messageColor}]### Notification (MQTT)')
+        console.print(f'Topic: {topic}')
+        topicArray = topic.split('/')
+        if len(topicArray) > 4 and topicArray[-4] == 'req' and topicArray[-5] == 'oneM2M':
+            _frm = topicArray[-3]
+            _to = topicArray[-2]
+            encoding = topicArray[-1]
+        else:
+            _frm = 'non-onem2m-entity'
+            _to = 'unknown'
+            encoding = 'json'
 
-	def onShutdown(self, connection: MQTTConnection) -> None:
-		if not self.isShutdown:
-			os.kill(os.getpid(), signal.SIGUSR1)
-	
+        # Print JSON
+        responseData = None
+        if encoding.upper() == 'JSON':
+            console.print(Syntax(json.dumps((jsn := json.loads(data)), indent=4),
+                                 'json',
+                                 theme='monokai',
+                                 line_numbers=False))
+            to = jsn['to'] if 'to' in jsn else _to
+            frm = jsn['fr'] if 'fr' in jsn else _frm
+            responseData = cast(bytes, serializeData(
+                _constructResponse(to, frm, jsn), ContentSerializationType.JSON))
+            console.print(responseData)
 
-	def _requestCB(self, connection:MQTTConnection, topic:str, data:bytes) -> None:
-		# TODO is it actually a notification? no -> do nothing, yes -> reply
+        # Print CBOR
+        elif encoding.upper() == 'CBOR':
+            console.print('[dim]Content as Hexdump:\n')
+            console.print(toHex(data), highlight=False)
+            console.print('\n[dim]Content as JSON:\n')
+            console.print(Syntax(json.dumps((jsn := cbor2.loads(data)), indent=4),
+                                 'json',
+                                 theme='monokai',
+                                 line_numbers=False))
+            to = jsn['to'] if 'to' in jsn else to
+            frm = jsn['fr'] if 'fr' in jsn else frm
+            responseData = cast(bytes, serializeData(
+                _constructResponse(to, frm, jsn), ContentSerializationType.CBOR))
 
-		def _constructResponse(frm:str, to:str, jsn:dict) -> dict:
-			responseData = 	{ 	'fr':	frm,
-								'to':	to, 
-								'rsc':	2000 if not failVerification else 4101,
-								'ot':	getResourceDate()
-							}
-			if (rqi := jsn.get('rqi')):
-				responseData['rqi'] = rqi
-			if (rvi := jsn.get('rvi')):
-				responseData['rvi'] = rvi
-			return responseData
+        # Print other binary content
+        else:
+            console.print('[dim]Content as Hexdump:\n')
+            console.print(toHex(data), highlight=False)
+        # TODO send a response
 
-
-		console.print(f'[{messageColor}]### Notification (MQTT)')
-		console.print(f'Topic: {topic}')
-		topicArray	= topic.split('/')
-		if len(topicArray) > 4 and topicArray[-4] == 'req' and topicArray[-5] == 'oneM2M':
-			_frm		= topicArray[-3]
-			_to			= topicArray[-2]
-			encoding	= topicArray[-1]
-		else:
-			_frm 		= 'non-onem2m-entity'	
-			_to 		= 'unknown'
-			encoding	= 'json'
-
-		# Print JSON
-		responseData = None
-		if encoding.upper() == 'JSON':
-			console.print(Syntax(json.dumps((jsn := json.loads(data)), indent=4),
-							 'json', 
-							 theme='monokai',
-							 line_numbers=False))
-			to 	= jsn['to'] if 'to' in jsn else _to
-			frm = jsn['fr'] if 'fr' in jsn else _frm
-			responseData = cast(bytes, serializeData(_constructResponse(to, frm, jsn), ContentSerializationType.JSON))
-			console.print(responseData)
-
-
-
-		# Print CBOR
-		elif encoding.upper() == 'CBOR':
-			console.print('[dim]Content as Hexdump:\n')
-			console.print(toHex(data), highlight=False)
-			console.print('\n[dim]Content as JSON:\n')
-			console.print(Syntax(json.dumps((jsn := cbor2.loads(data)), indent=4),
-							 'json', 
-							 theme='monokai',
-							 line_numbers=False))		
-			to 	= jsn['to'] if 'to' in jsn else to
-			frm = jsn['fr'] if 'fr' in jsn else frm
-			responseData = cast(bytes, serializeData(_constructResponse(to, frm, jsn), ContentSerializationType.CBOR))
-
-		# Print other binary content
-		else:
-			console.print('[dim]Content as Hexdump:\n')
-			console.print(toHex(data), highlight=False)
-		# TODO send a response
-
-		if responseData:
-			# connection.publish(f'/oneM2M/resp{frm}/{to.lstrip("/").replace("/", ":")}/{encoding}', responseData)
-			connection.publish(f'/oneM2M/resp/{_frm}/{_to}/{encoding}', responseData)
+        if responseData:
+            # connection.publish(f'/oneM2M/resp{frm}/{to.lstrip("/").replace("/", ":")}/{encoding}', responseData)
+            connection.publish(
+                f'/oneM2M/resp/{_frm}/{_to}/{encoding}', responseData)
 
 
 class MQTTClient(object):
 
-	def __init__(self, args:argparse.Namespace) -> None:
-		# Assume a couple of meaningful defaults here
-		self.mqttConnection = MQTTConnection(address			= args.mqttAddress,
-											 port				= args.mqttPort,
-											 keepalive			= 60,
-											 interface			= '0.0.0.0',
-											 username 			= args.mqttUsername,
-											 password			= args.mqttPassword,
-											 messageHandler 	= MQTTClientHandler	(args.mqttTopic, args.mqttLogging))
-	
+    def __init__(self, args: argparse.Namespace) -> None:
+        # Assume a couple of meaningful defaults here
+        self.mqttConnection = MQTTConnection(address=args.mqttAddress,
+                                             port=args.mqttPort,
+                                             keepalive=60,
+                                             interface='0.0.0.0',
+                                             username=args.mqttUsername,
+                                             password=args.mqttPassword,
+                                             # MIO_AID MQTTS Added 09.11.2022 START
+                                             useTLS=args.mqtts,
+                                             cafile=args.caFile,
+                                             certfile=args.mqttCert,
+                                             keyfile=args.mqttKey,
+                                             # MIO_AID MQTTS END
+                                             messageHandler=MQTTClientHandler(args.mqttTopic, args.mqttLogging))
 
-	def run(self) -> None:
-		self.mqttConnection.run()
-		console.print(f'[{messageColor}]MQTT client started. Connected to {args.mqttAddress}:{args.mqttPort}.')
-	
+    def run(self) -> None:
+        self.mqttConnection.run()
+        console.print(
+            f'[{messageColor}]MQTT client started. Connected to {args.mqttAddress}:{args.mqttPort}.')
 
-	def shutdown(self) -> None:
-		self.mqttConnection.messageHandler.isShutdown = True	# type:ignore [attr-defined]
-		if self.mqttConnection:
-			self.mqttConnection.shutdown()
-			console.print(f'[{messageColor}]MQTT client stopped.')
-	
+    def shutdown(self) -> None:
+        # type:ignore [attr-defined]
+        self.mqttConnection.messageHandler.isShutdown = True
+        if self.mqttConnection:
+            self.mqttConnection.shutdown()
+            console.print(f'[{messageColor}]MQTT client stopped.')
+
 ##############################################################################
 
 #
-#	Help with exiting and terminating all the threads programmatically
-#	
-class ExitCommand(Exception):
-	pass
+# Help with exiting and terminating all the threads programmatically
+#
 
-def exitSignalHandler(signal, frame) -> None:	# type: ignore [no-untyped-def]
-	raise ExitCommand()
+
+class ExitCommand(Exception):
+    pass
+
+
+def exitSignalHandler(signal, frame) -> None:  # type: ignore [no-untyped-def]
+    raise ExitCommand()
+
 
 def exitAll() -> None:
-	os.kill(os.getpid(), signal.SIGUSR1)
+    os.kill(os.getpid(), signal.SIGUSR1)
+
 
 signal.signal(signal.SIGUSR1, exitSignalHandler)
-	
+
 if __name__ == '__main__':
-	console = Console()
-	console.print(f'\n{C.textLogo} - [bold]Notification Server[/bold]\n\n')
+    console = Console()
+    console.print(f'\n{C.textLogo} - [bold]Notification Server[/bold]\n\n')
 
+    # parse command line argiments
+    parser = argparse.ArgumentParser()
 
-	# parse command line argiments
-	parser = argparse.ArgumentParser()
+    # mutual exlcusive arguments for http
+    groupHttp = parser.add_mutually_exclusive_group()
+    groupHttp.add_argument('--http', action='store_false', dest='usehttps',
+                           default=None, help='run as http server (the default)')
+    groupHttp.add_argument('--https', action='store_true',
+                           dest='usehttps', default=None, help='run as https server')
+    parser.add_argument('--port', action='store', dest='port',
+                        default=port, type=int, help='specify the server port')
+    parser.add_argument('--certfile', action='store', dest='certfile', required='--https' in sys.argv,
+                        metavar='<filename>', help='specify the certificate file for https')
+    parser.add_argument('--keyfile', action='store', dest='keyfile', required='--https' in sys.argv,
+                        metavar='<filename>', 	help='specify the key file for https')
 
-	# mutual exlcusive arguments for http
-	groupHttp = parser.add_mutually_exclusive_group()
-	groupHttp.add_argument('--http', action='store_false', dest='usehttps', default=None, help='run as http server (the default)')
-	groupHttp.add_argument('--https', action='store_true', dest='usehttps', default=None, help='run as https server')
-	parser.add_argument('--port', action='store', dest='port', default=port, type=int, help='specify the server port')
-	parser.add_argument('--certfile', action='store', dest='certfile', required='--https' in sys.argv, metavar='<filename>', help='specify the certificate file for https')
-	parser.add_argument('--keyfile', action='store', dest='keyfile', required='--https' in sys.argv, metavar='<filename>', 	help='specify the key file for https')
+    # MQTT arguments
+    parser.add_argument('--mqtt', action='store_true', dest='mqtt',
+                        default=False, help='enable MQTT for notifications')
+    parser.add_argument('--mqtt-address', action='store', dest='mqttAddress', default='localhost',
+                        required='--mqtt' in sys.argv, metavar='<host>', help='MQTT broker address (default: localhost)')
+    parser.add_argument('--mqtt-port', action='store', dest='mqttPort',
+                        default=1883, metavar='<port>',  help='MQTT broker port (default: 1883)')
+    parser.add_argument('--mqtt-topic', action='store', dest='mqttTopic', default=mqttNotificationTopic,
+                        metavar='<topic>', nargs='+', help=f'MQTT topic list (default: {mqttNotificationTopic})')
+    parser.add_argument('--mqtt-username', action='store', dest='mqttUsername',
+                        default=None, metavar='<username>',  help='MQTT username (default: None)')
+    parser.add_argument('--mqtt-password', action='store', dest='mqttPassword', default=None,
+                        required='--mqttUsername' in sys.argv, metavar='<password>',  help='MQTT password (default: None)')
+    parser.add_argument('--mqtt-logging', action='store_true', dest='mqttLogging',
+                        default=False, help='MQTT enable logging (default: disabled)')
+    # MIO AID 09.11.2022 added
+    parser.add_argument('--mqtt-useTLS', action='store_true', dest='mqtts',
+                        default=False, help='Enable MQTTS (default: disabled)')
+    parser.add_argument('--mqtt-caFile', action='store', metavar='<cafile>', dest='caFile',
+                        default=None, help='CA.crt File (default: None)')
+    parser.add_argument('--mqtt-certfile', action='store', metavar='<certfile>', dest='mqttCert',
+                        default=None, help='Cert-File for MQTTS (default: None)')
+    parser.add_argument('--mqtt-keyfile', action='store', metavar='<keyfile>', dest='mqttKey',
+                        default=None, help='Key-File for MQTTS (default: None)')
+    # END
 
-	# MQTT arguments
-	parser.add_argument('--mqtt', action='store_true', dest='mqtt', default=False, help='enable MQTT for notifications')
-	parser.add_argument('--mqtt-address', action='store', dest='mqttAddress', default='localhost', required='--mqtt' in sys.argv, metavar='<host>', help='MQTT broker address (default: localhost)')
-	parser.add_argument('--mqtt-port', action='store', dest='mqttPort', default=1883, metavar='<port>',  help='MQTT broker port (default: 1883)')
-	parser.add_argument('--mqtt-topic', action='store', dest='mqttTopic', default=mqttNotificationTopic, metavar='<topic>', nargs='+', help=f'MQTT topic list (default: {mqttNotificationTopic})')
-	parser.add_argument('--mqtt-username', action='store', dest='mqttUsername', default=None, metavar='<username>',  help='MQTT username (default: None)')
-	parser.add_argument('--mqtt-password', action='store', dest='mqttPassword', default=None, required='--mqttUsername' in sys.argv, metavar='<password>',  help='MQTT password (default: None)')
-	parser.add_argument('--mqtt-logging', action='store_true', dest='mqttLogging', default=False, help='MQTT enable logging (default: disabled)')
+    # Generic
+    parser.add_argument('--fail-verification', action='store_true', dest='failVerification',
+                        default=False, help='Fail verification requests (default: false)')
 
-	# Generic
-	parser.add_argument('--fail-verification', action='store_true', dest='failVerification', default=False, help='Fail verification requests (default: false)')
+    args = parser.parse_args()
 
+    # Generic arguments
+    failVerification = args.failVerification
 
+    # run http(s) server
+    httpd = HTTPServer(('', args.port), SimpleHTTPRequestHandler)
 
-	args = parser.parse_args()
+    if args.usehttps:
+        # init ssl socket
+        # Create a SSL Context
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        # Load the certificate and private key
+        context.load_cert_chain(args.certfile, args.keyfile)
+        # wrap the original http server socket as an SSL/TLS socket
+        httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
 
-	# Generic arguments
-	failVerification = args.failVerification
+    console.print(f'[{messageColor}]Notification server started.')
+    try:
+        # run mqtt client
+        mqttClient = None
+        if args.mqtt:
+            mqttClient = MQTTClient(args)
+            mqttClient.run()
 
-	# run http(s) server
-	httpd = HTTPServer(('', args.port), SimpleHTTPRequestHandler)
-	
-	if args.usehttps:
-		# init ssl socket
-		context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)					# Create a SSL Context
-		context.load_cert_chain(args.certfile, args.keyfile)				# Load the certificate and private key
-		httpd.socket = context.wrap_socket(httpd.socket, server_side=True)	# wrap the original http server socket as an SSL/TLS socket
-	
-	console.print(f'[{messageColor}]Notification server started.')
-	try:
-		# run mqtt client
-		mqttClient = None
-		if args.mqtt:
-			mqttClient = MQTTClient(args)
-			mqttClient.run()
-
-		# run http server
-		console.print(f'[{messageColor}]Listening for http(s) connections on port {args.port}.')
-		httpd.serve_forever()
-	except KeyboardInterrupt as e:
-		if mqttClient:
-			mqttClient.shutdown()
-		# The http server is stopped implicitly
-	except ExitCommand:
-		pass
-	except Exception:
-		console.print()
-		console.print_exception()
-	finally:
-		console.print(f'[{messageColor}]Notification server stopped.')
-
+        # run http server
+        console.print(
+            f'[{messageColor}]Listening for http(s) connections on port {args.port}.')
+        httpd.serve_forever()
+    except KeyboardInterrupt as e:
+        if mqttClient:
+            mqttClient.shutdown()
+        # The http server is stopped implicitly
+    except ExitCommand:
+        pass
+    except Exception:
+        console.print()
+        console.print_exception()
+    finally:
+        console.print(f'[{messageColor}]Notification server stopped.')

--- a/tools/notificationServer/notificationServer.py
+++ b/tools/notificationServer/notificationServer.py
@@ -29,8 +29,6 @@ from acme.etc.DateUtils import getResourceDate
 from acme.etc.Types import ContentSerializationType
 from acme.etc.Constants import Constants as C
 
-import ssl
-
 ##############################################################################
 #
 # HTTP Server
@@ -45,71 +43,71 @@ failVerification = False
 
 class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
 
-    def do_GET(self) -> None:
-        """	Just provide a simple web page.
-        """
-        self.send_response(200)
-        self.send_header('Content-type', 'text/html')
-        self.end_headers()
-        self.wfile.write(bytes(
-            "<html><head><title>[ACME] Notification Server</title></head><body>This server doesn't provide a web page.</body></html>", "utf-8"))
+	def do_GET(self) -> None:
+		"""	Just provide a simple web page.
+		"""
+		self.send_response(200)
+		self.send_header('Content-type', 'text/html')
+		self.end_headers()
+		self.wfile.write(bytes(
+			"<html><head><title>[ACME] Notification Server</title></head><body>This server doesn't provide a web page.</body></html>", "utf-8"))
 
-    def do_POST(self) -> None:
-        """	Handle notification.
-        """
+	def do_POST(self) -> None:
+		"""	Handle notification.
+		"""
 
-        _responseHeaders: list = []
+		_responseHeaders: list = []
 
-        # Get headers and content data
-        length = int(self.headers['Content-Length'])
-        contentType = self.headers['Content-Type']
-        requestID = self.headers['X-M2M-RI']
-        post_data = self.rfile.read(length)
+		# Get headers and content data
+		length = int(self.headers['Content-Length'])
+		contentType = self.headers['Content-Type']
+		requestID = self.headers['X-M2M-RI']
+		post_data = self.rfile.read(length)
 
-        # Construct return header
-        # Always acknowledge the verification requests
-        self.send_response(200)
-        self.send_header(
-            'X-M2M-RSC', '2000' if not failVerification else '4101')
-        self.send_header('X-M2M-RI', requestID)
-        _responseHeaders = self._headers_buffer  # type:ignore [attr-defined]
-        self.end_headers()
+		# Construct return header
+		# Always acknowledge the verification requests
+		self.send_response(200)
+		self.send_header(
+			'X-M2M-RSC', '2000' if not failVerification else '4101')
+		self.send_header('X-M2M-RI', requestID)
+		_responseHeaders = self._headers_buffer  # type:ignore [attr-defined]
+		self.end_headers()
 
-        # Print the content data
-        console.print(f'[{messageColor}]### Notification (http)')
-        console.print(self.headers, highlight=False)
+		# Print the content data
+		console.print(f'[{messageColor}]### Notification (http)')
+		console.print(self.headers, highlight=False)
 
-        # Print JSON
-        if contentType in ['application/json', 'application/vnd.onem2m-res+json']:
-            console.print(Syntax(json.dumps(json.loads(post_data.decode('utf-8')), indent=4),
-                                 'json',
-                                 theme='monokai',
-                                 line_numbers=False))
+		# Print JSON
+		if contentType in ['application/json', 'application/vnd.onem2m-res+json']:
+			console.print(Syntax(json.dumps(json.loads(post_data.decode('utf-8')), indent=4),
+								 'json',
+								 theme='monokai',
+								 line_numbers=False))
 
-        # Print CBOR
-        elif contentType in ['application/cbor', 'application/vnd.onem2m-res+cbor']:
-            console.print('[dim]Content as Hexdump:\n')
-            console.print(toHex(post_data), highlight=False)
-            console.print('\n[dim]Content as JSON:\n')
-            console.print(Syntax(json.dumps(cbor2.loads(post_data), indent=4),
-                                 'json',
-                                 theme='monokai',
-                                 line_numbers=False))
+		# Print CBOR
+		elif contentType in ['application/cbor', 'application/vnd.onem2m-res+cbor']:
+			console.print('[dim]Content as Hexdump:\n')
+			console.print(toHex(post_data), highlight=False)
+			console.print('\n[dim]Content as JSON:\n')
+			console.print(Syntax(json.dumps(cbor2.loads(post_data), indent=4),
+								 'json',
+								 theme='monokai',
+								 line_numbers=False))
 
-        # Print other binary content
-        else:
-            console.print(toHex(post_data), highlight=False)
+		# Print other binary content
+		else:
+			console.print(toHex(post_data), highlight=False)
 
-        # Print HTTP Response
-        # This looks a it more complicated but is necessary to render nicely in Jupyter
-        console.print(f'[{messageColor}]### Notification Response (http)')
-        console.print(email.parser.Parser(_class=HTTPMessage).parsestr(
-            b''.join(_responseHeaders).decode('iso-8859-1')), highlight=False)
+		# Print HTTP Response
+		# This looks a it more complicated but is necessary to render nicely in Jupyter
+		console.print(f'[{messageColor}]### Notification Response (http)')
+		console.print(email.parser.Parser(_class=HTTPMessage).parsestr(
+			b''.join(_responseHeaders).decode('iso-8859-1')), highlight=False)
 
-    def log_message(self, format: str, *args: int) -> None:
-        if (msg := format % args).startswith('"GET'):
-            return  # ignore GET log messages
-        console.print(f'[{messageColor} reverse]{msg}', highlight=False)
+	def log_message(self, format: str, *args: int) -> None:
+		if (msg := format % args).startswith('"GET'):
+			return  # ignore GET log messages
+		console.print(f'[{messageColor} reverse]{msg}', highlight=False)
 
 
 ##############################################################################
@@ -122,137 +120,135 @@ mqttNotificationTopic = ['/oneM2M/req/id-in/+/#']
 
 class MQTTClientHandler(MQTTHandler):
 
-    def __init__(self, topic: str | list[str], enableLogging: bool) -> None:
-        super().__init__()
-        self.topic = topic
-        self.enableLogging = enableLogging
-        self.isShutdown = False
+	def __init__(self, topic: str | list[str], enableLogging: bool) -> None:
+		super().__init__()
+		self.topic = topic
+		self.enableLogging = enableLogging
+		self.isShutdown = False
 
-    def onConnect(self, connection: MQTTConnection) -> bool:
-        try:
-            # Subscribe to general requests
-            connection.subscribeTopic(self.topic, self._requestCB)
-        except Exception as e:
-            self.onError(connection, -1, f'MQTT {str(e)}')
-        return True
+	def onConnect(self, connection: MQTTConnection) -> bool:
+		try:
+			# Subscribe to general requests
+			connection.subscribeTopic(self.topic, self._requestCB)
+		except Exception as e:
+			self.onError(connection, -1, f'MQTT {str(e)}')
+		return True
 
-    def onError(self, connection: MQTTConnection, rc: int = -1, msg: str = None) -> bool:
-        if rc in [5]:		# authorization error
-            console.print(f'[{errorColor}]MQTT authorization error')
-            connection.shutdown()
-            console.print(f'[{messageColor}]MQTT client shutdown')
-        if rc == -1: 	# unknown. probably connection error?
-            if msg:
-                console.print(f'[{errorColor}]{msg}')
-            connection.shutdown()
-            console.print(f'[{messageColor}]MQTT client shutdown')
-        # ignore all others
-        return True
+	def onError(self, connection: MQTTConnection, rc: int = -1, msg: str = None) -> bool:
+		if rc in [5]:		# authorization error
+			console.print(f'[{errorColor}]MQTT authorization error')
+			connection.shutdown()
+			console.print(f'[{messageColor}]MQTT client shutdown')
+		if rc == -1: 	# unknown. probably connection error?
+			if msg:
+				console.print(f'[{errorColor}]{msg}')
+			connection.shutdown()
+			console.print(f'[{messageColor}]MQTT client shutdown')
+		# ignore all others
+		return True
 
-    def logging(self, connection: MQTTConnection, level: int, message: str) -> bool:
-        if self.enableLogging:
-            console.print(f'{level}: {message}')
-        return True
+	def logging(self, connection: MQTTConnection, level: int, message: str) -> bool:
+		if self.enableLogging:
+			console.print(f'{level}: {message}')
+		return True
 
-    def onShutdown(self, connection: MQTTConnection) -> None:
-        if not self.isShutdown:
-            os.kill(os.getpid(), signal.SIGUSR1)
+	def onShutdown(self, connection: MQTTConnection) -> None:
+		if not self.isShutdown:
+			os.kill(os.getpid(), signal.SIGUSR1)
 
-    def _requestCB(self, connection: MQTTConnection, topic: str, data: bytes) -> None:
-        # TODO is it actually a notification? no -> do nothing, yes -> reply
+	def _requestCB(self, connection: MQTTConnection, topic: str, data: bytes) -> None:
+		# TODO is it actually a notification? no -> do nothing, yes -> reply
 
-        def _constructResponse(frm: str, to: str, jsn: dict) -> dict:
-            responseData = {'fr': frm,
-                            'to':	to,
-                            'rsc':	2000 if not failVerification else 4101,
-                            'ot':	getResourceDate()
-                            }
-            if (rqi := jsn.get('rqi')):
-                responseData['rqi'] = rqi
-            if (rvi := jsn.get('rvi')):
-                responseData['rvi'] = rvi
-            return responseData
+		def _constructResponse(frm: str, to: str, jsn: dict) -> dict:
+			responseData = {'fr': frm,
+							'to':	to,
+							'rsc':	2000 if not failVerification else 4101,
+							'ot':	getResourceDate()
+							}
+			if (rqi := jsn.get('rqi')):
+				responseData['rqi'] = rqi
+			if (rvi := jsn.get('rvi')):
+				responseData['rvi'] = rvi
+			return responseData
 
-        console.print(f'[{messageColor}]### Notification (MQTT)')
-        console.print(f'Topic: {topic}')
-        topicArray = topic.split('/')
-        if len(topicArray) > 4 and topicArray[-4] == 'req' and topicArray[-5] == 'oneM2M':
-            _frm = topicArray[-3]
-            _to = topicArray[-2]
-            encoding = topicArray[-1]
-        else:
-            _frm = 'non-onem2m-entity'
-            _to = 'unknown'
-            encoding = 'json'
+		console.print(f'[{messageColor}]### Notification (MQTT)')
+		console.print(f'Topic: {topic}')
+		topicArray = topic.split('/')
+		if len(topicArray) > 4 and topicArray[-4] == 'req' and topicArray[-5] == 'oneM2M':
+			_frm = topicArray[-3]
+			_to = topicArray[-2]
+			encoding = topicArray[-1]
+		else:
+			_frm = 'non-onem2m-entity'
+			_to = 'unknown'
+			encoding = 'json'
 
-        # Print JSON
-        responseData = None
-        if encoding.upper() == 'JSON':
-            console.print(Syntax(json.dumps((jsn := json.loads(data)), indent=4),
-                                 'json',
-                                 theme='monokai',
-                                 line_numbers=False))
-            to = jsn['to'] if 'to' in jsn else _to
-            frm = jsn['fr'] if 'fr' in jsn else _frm
-            responseData = cast(bytes, serializeData(
-                _constructResponse(to, frm, jsn), ContentSerializationType.JSON))
-            console.print(responseData)
+		# Print JSON
+		responseData = None
+		if encoding.upper() == 'JSON':
+			console.print(Syntax(json.dumps((jsn := json.loads(data)), indent=4),
+								 'json',
+								 theme='monokai',
+								 line_numbers=False))
+			to = jsn['to'] if 'to' in jsn else _to
+			frm = jsn['fr'] if 'fr' in jsn else _frm
+			responseData = cast(bytes, serializeData(
+				_constructResponse(to, frm, jsn), ContentSerializationType.JSON))
+			console.print(responseData)
 
-        # Print CBOR
-        elif encoding.upper() == 'CBOR':
-            console.print('[dim]Content as Hexdump:\n')
-            console.print(toHex(data), highlight=False)
-            console.print('\n[dim]Content as JSON:\n')
-            console.print(Syntax(json.dumps((jsn := cbor2.loads(data)), indent=4),
-                                 'json',
-                                 theme='monokai',
-                                 line_numbers=False))
-            to = jsn['to'] if 'to' in jsn else to
-            frm = jsn['fr'] if 'fr' in jsn else frm
-            responseData = cast(bytes, serializeData(
-                _constructResponse(to, frm, jsn), ContentSerializationType.CBOR))
+		# Print CBOR
+		elif encoding.upper() == 'CBOR':
+			console.print('[dim]Content as Hexdump:\n')
+			console.print(toHex(data), highlight=False)
+			console.print('\n[dim]Content as JSON:\n')
+			console.print(Syntax(json.dumps((jsn := cbor2.loads(data)), indent=4),
+								 'json',
+								 theme='monokai',
+								 line_numbers=False))
+			to = jsn['to'] if 'to' in jsn else to
+			frm = jsn['fr'] if 'fr' in jsn else frm
+			responseData = cast(bytes, serializeData(
+				_constructResponse(to, frm, jsn), ContentSerializationType.CBOR))
 
-        # Print other binary content
-        else:
-            console.print('[dim]Content as Hexdump:\n')
-            console.print(toHex(data), highlight=False)
-        # TODO send a response
+		# Print other binary content
+		else:
+			console.print('[dim]Content as Hexdump:\n')
+			console.print(toHex(data), highlight=False)
+		# TODO send a response
 
-        if responseData:
-            # connection.publish(f'/oneM2M/resp{frm}/{to.lstrip("/").replace("/", ":")}/{encoding}', responseData)
-            connection.publish(
-                f'/oneM2M/resp/{_frm}/{_to}/{encoding}', responseData)
+		if responseData:
+			# connection.publish(f'/oneM2M/resp{frm}/{to.lstrip("/").replace("/", ":")}/{encoding}', responseData)
+			connection.publish(
+				f'/oneM2M/resp/{_frm}/{_to}/{encoding}', responseData)
 
 
 class MQTTClient(object):
 
-    def __init__(self, args: argparse.Namespace) -> None:
-        # Assume a couple of meaningful defaults here
-        self.mqttConnection = MQTTConnection(address=args.mqttAddress,
-                                             port=args.mqttPort,
-                                             keepalive=60,
-                                             interface='0.0.0.0',
-                                             username=args.mqttUsername,
-                                             password=args.mqttPassword,
-                                             # MIO_AID MQTTS Added 09.11.2022 START
-                                             useTLS=args.mqtts,
-                                             cafile=args.caFile,
-                                             certfile=args.mqttCert,
-                                             keyfile=args.mqttKey,
-                                             # MIO_AID MQTTS END
-                                             messageHandler=MQTTClientHandler(args.mqttTopic, args.mqttLogging))
+	def __init__(self, args: argparse.Namespace) -> None:
+		# Assume a couple of meaningful defaults here
+		self.mqttConnection = MQTTConnection(address=args.mqttAddress,
+											 port=args.mqttPort,
+											 keepalive=60,
+											 interface='0.0.0.0',
+											 username=args.mqttUsername,
+											 password=args.mqttPassword,
+											 useTLS=args.mqtts,
+											 cafile=args.caFile,
+											 certfile=args.mqttCert,
+											 keyfile=args.mqttKey,
+											 messageHandler=MQTTClientHandler(args.mqttTopic, args.mqttLogging))
 
-    def run(self) -> None:
-        self.mqttConnection.run()
-        console.print(
-            f'[{messageColor}]MQTT client started. Connected to {args.mqttAddress}:{args.mqttPort}.')
+	def run(self) -> None:
+		self.mqttConnection.run()
+		console.print(
+			f'[{messageColor}]MQTT client started. Connected to {args.mqttAddress}:{args.mqttPort}.')
 
-    def shutdown(self) -> None:
-        # type:ignore [attr-defined]
-        self.mqttConnection.messageHandler.isShutdown = True
-        if self.mqttConnection:
-            self.mqttConnection.shutdown()
-            console.print(f'[{messageColor}]MQTT client stopped.')
+	def shutdown(self) -> None:
+		# type:ignore [attr-defined]
+		self.mqttConnection.messageHandler.isShutdown = True
+		if self.mqttConnection:
+			self.mqttConnection.shutdown()
+			console.print(f'[{messageColor}]MQTT client stopped.')
 
 ##############################################################################
 
@@ -262,106 +258,104 @@ class MQTTClient(object):
 
 
 class ExitCommand(Exception):
-    pass
+	pass
 
 
 def exitSignalHandler(signal, frame) -> None:  # type: ignore [no-untyped-def]
-    raise ExitCommand()
+	raise ExitCommand()
 
 
 def exitAll() -> None:
-    os.kill(os.getpid(), signal.SIGUSR1)
+	os.kill(os.getpid(), signal.SIGUSR1)
 
 
 signal.signal(signal.SIGUSR1, exitSignalHandler)
 
 if __name__ == '__main__':
-    console = Console()
-    console.print(f'\n{C.textLogo} - [bold]Notification Server[/bold]\n\n')
+	console = Console()
+	console.print(f'\n{C.textLogo} - [bold]Notification Server[/bold]\n\n')
 
-    # parse command line argiments
-    parser = argparse.ArgumentParser()
+	# parse command line argiments
+	parser = argparse.ArgumentParser()
 
-    # mutual exlcusive arguments for http
-    groupHttp = parser.add_mutually_exclusive_group()
-    groupHttp.add_argument('--http', action='store_false', dest='usehttps',
-                           default=None, help='run as http server (the default)')
-    groupHttp.add_argument('--https', action='store_true',
-                           dest='usehttps', default=None, help='run as https server')
-    parser.add_argument('--port', action='store', dest='port',
-                        default=port, type=int, help='specify the server port')
-    parser.add_argument('--certfile', action='store', dest='certfile', required='--https' in sys.argv,
-                        metavar='<filename>', help='specify the certificate file for https')
-    parser.add_argument('--keyfile', action='store', dest='keyfile', required='--https' in sys.argv,
-                        metavar='<filename>', 	help='specify the key file for https')
+	# mutual exlcusive arguments for http
+	groupHttp = parser.add_mutually_exclusive_group()
+	groupHttp.add_argument('--http', action='store_false', dest='usehttps',
+						   default=None, help='run as http server (the default)')
+	groupHttp.add_argument('--https', action='store_true',
+						   dest='usehttps', default=None, help='run as https server')
+	parser.add_argument('--port', action='store', dest='port',
+						default=port, type=int, help='specify the server port')
+	parser.add_argument('--certfile', action='store', dest='certfile', required='--https' in sys.argv,
+						metavar='<filename>', help='specify the certificate file for https')
+	parser.add_argument('--keyfile', action='store', dest='keyfile', required='--https' in sys.argv,
+						metavar='<filename>', 	help='specify the key file for https')
 
-    # MQTT arguments
-    parser.add_argument('--mqtt', action='store_true', dest='mqtt',
-                        default=False, help='enable MQTT for notifications')
-    parser.add_argument('--mqtt-address', action='store', dest='mqttAddress', default='localhost',
-                        required='--mqtt' in sys.argv, metavar='<host>', help='MQTT broker address (default: localhost)')
-    parser.add_argument('--mqtt-port', action='store', dest='mqttPort',
-                        default=1883, metavar='<port>',  help='MQTT broker port (default: 1883)')
-    parser.add_argument('--mqtt-topic', action='store', dest='mqttTopic', default=mqttNotificationTopic,
-                        metavar='<topic>', nargs='+', help=f'MQTT topic list (default: {mqttNotificationTopic})')
-    parser.add_argument('--mqtt-username', action='store', dest='mqttUsername',
-                        default=None, metavar='<username>',  help='MQTT username (default: None)')
-    parser.add_argument('--mqtt-password', action='store', dest='mqttPassword', default=None,
-                        required='--mqttUsername' in sys.argv, metavar='<password>',  help='MQTT password (default: None)')
-    parser.add_argument('--mqtt-logging', action='store_true', dest='mqttLogging',
-                        default=False, help='MQTT enable logging (default: disabled)')
-    # MIO AID 09.11.2022 added
-    parser.add_argument('--mqtt-useTLS', action='store_true', dest='mqtts',
-                        default=False, help='Enable MQTTS (default: disabled)')
-    parser.add_argument('--mqtt-caFile', action='store', metavar='<cafile>', dest='caFile',
-                        default=None, help='CA.crt File (default: None)')
-    parser.add_argument('--mqtt-certfile', action='store', metavar='<certfile>', dest='mqttCert',
-                        default=None, help='Cert-File for MQTTS (default: None)')
-    parser.add_argument('--mqtt-keyfile', action='store', metavar='<keyfile>', dest='mqttKey',
-                        default=None, help='Key-File for MQTTS (default: None)')
-    # END
+	# MQTT arguments
+	parser.add_argument('--mqtt', action='store_true', dest='mqtt',
+						default=False, help='enable MQTT for notifications')
+	parser.add_argument('--mqtt-address', action='store', dest='mqttAddress', default='localhost',
+						required='--mqtt' in sys.argv, metavar='<host>', help='MQTT broker address (default: localhost)')
+	parser.add_argument('--mqtt-port', action='store', dest='mqttPort',
+						default=1883, metavar='<port>',  help='MQTT broker port (default: 1883)')
+	parser.add_argument('--mqtt-topic', action='store', dest='mqttTopic', default=mqttNotificationTopic,
+						metavar='<topic>', nargs='+', help=f'MQTT topic list (default: {mqttNotificationTopic})')
+	parser.add_argument('--mqtt-username', action='store', dest='mqttUsername',
+						default=None, metavar='<username>',  help='MQTT username (default: None)')
+	parser.add_argument('--mqtt-password', action='store', dest='mqttPassword', default=None,
+						required='--mqttUsername' in sys.argv, metavar='<password>',  help='MQTT password (default: None)')
+	parser.add_argument('--mqtt-logging', action='store_true', dest='mqttLogging',
+						default=False, help='MQTT enable logging (default: disabled)')
+	parser.add_argument('--mqtt-useTLS', action='store_true', dest='mqtts',
+						default=False, help='Enable MQTTS (default: disabled)')
+	parser.add_argument('--mqtt-caFile', action='store', metavar='<cafile>', dest='caFile',
+						default=None, help='CA Certficiate ca.crt file (default: None)')
+	parser.add_argument('--mqtt-certfile', action='store', metavar='<certfile>', dest='mqttCert',
+						default=None, help='Certificate file *.crt for MQTTS (default: None)')
+	parser.add_argument('--mqtt-keyfile', action='store', metavar='<keyfile>', dest='mqttKey',
+						default=None, help='Key file *.key for MQTTS (default: None)')
 
-    # Generic
-    parser.add_argument('--fail-verification', action='store_true', dest='failVerification',
-                        default=False, help='Fail verification requests (default: false)')
+	# Generic
+	parser.add_argument('--fail-verification', action='store_true', dest='failVerification',
+						default=False, help='Fail verification requests (default: false)')
 
-    args = parser.parse_args()
+	args = parser.parse_args()
 
-    # Generic arguments
-    failVerification = args.failVerification
+	# Generic arguments
+	failVerification = args.failVerification
 
-    # run http(s) server
-    httpd = HTTPServer(('', args.port), SimpleHTTPRequestHandler)
+	# run http(s) server
+	httpd = HTTPServer(('', args.port), SimpleHTTPRequestHandler)
 
-    if args.usehttps:
-        # init ssl socket
-        # Create a SSL Context
-        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-        # Load the certificate and private key
-        context.load_cert_chain(args.certfile, args.keyfile)
-        # wrap the original http server socket as an SSL/TLS socket
-        httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
+	if args.usehttps:
+		# init ssl socket
+		# Create a SSL Context
+		context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+		# Load the certificate and private key
+		context.load_cert_chain(args.certfile, args.keyfile)
+		# wrap the original http server socket as an SSL/TLS socket
+		httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
 
-    console.print(f'[{messageColor}]Notification server started.')
-    try:
-        # run mqtt client
-        mqttClient = None
-        if args.mqtt:
-            mqttClient = MQTTClient(args)
-            mqttClient.run()
+	console.print(f'[{messageColor}]Notification server started.')
+	try:
+		# run mqtt client
+		mqttClient = None
+		if args.mqtt:
+			mqttClient = MQTTClient(args)
+			mqttClient.run()
 
-        # run http server
-        console.print(
-            f'[{messageColor}]Listening for http(s) connections on port {args.port}.')
-        httpd.serve_forever()
-    except KeyboardInterrupt as e:
-        if mqttClient:
-            mqttClient.shutdown()
-        # The http server is stopped implicitly
-    except ExitCommand:
-        pass
-    except Exception:
-        console.print()
-        console.print_exception()
-    finally:
-        console.print(f'[{messageColor}]Notification server stopped.')
+		# run http server
+		console.print(
+			f'[{messageColor}]Listening for http(s) connections on port {args.port}.')
+		httpd.serve_forever()
+	except KeyboardInterrupt as e:
+		if mqttClient:
+			mqttClient.shutdown()
+		# The http server is stopped implicitly
+	except ExitCommand:
+		pass
+	except Exception:
+		console.print()
+		console.print_exception()
+	finally:
+		console.print(f'[{messageColor}]Notification server stopped.')


### PR DESCRIPTION
New Notification Server Arguments:
--mqtt-useTLS: Enabling MQTTS
--mqtt-caFile: Path to CA.crt file
--mqtt-certfile: Path to certfile.crt
--mqtt-keyfile: Path to keyfile.key

Example:
`python3 notificationServer.py --mqtt --mqtt-address mosquitto --mqtt-port 8883 --mqtt-useTLS --mqtt-caFile ca.crt --mqtt-certfile certfile.crt --mqtt-keyfile keyfile.key --mqtt-topic /oneM2M/req/id-in/+/# --mqtt-logging`