### PR TITLE
Websocket support for mqtt

### DIFF
--- a/acme/helpers/MQTTConnection.py
+++ b/acme/helpers/MQTTConnection.py
@@ -170,6 +170,8 @@ class MQTTConnection(object):
 		'messageHandler',
 		'actor',
 		'subscribedTopics',
+		'transport',
+		'websocketPath',
 	)
 	"""	Slots of the class. """
 
@@ -190,7 +192,9 @@ class MQTTConnection(object):
 					   certfile:Optional[str] = None, 
 					   keyfile:Optional[str] = None,
 					   lowLevelLogging:bool = True,
-					   messageHandler:Optional[MQTTHandler] = None
+					   messageHandler:Optional[MQTTHandler] = None,
+					   transport: Literal["tcp", "websockets"] = "tcp",
+					   websocketPath: Optional[str] = None
 				) -> None:
 		"""	Constructor. Initialize the MQTT client.
 
@@ -209,6 +213,8 @@ class MQTTConnection(object):
 				keyfile: The key file for the MQTT client.
 				lowLevelLogging: Indicator whether to log MQTT messages.
 				messageHandler: The message handler.
+				transport: The transport protocol to use (tcp or websockets).
+				websocketPath: The websocket path to use (incase of websockets).
 		"""
 		
 		self.address								= address
@@ -255,6 +261,14 @@ class MQTTConnection(object):
 		self.subscribedTopics:dict[str, MQTTTopic]	= {}
 		""" The list of subscribed-to topics. """
 
+		transport = transport.lower()  # type: ignore
+		if transport not in ("websockets", "tcp"):
+			raise ValueError(
+				f'transport must be "websockets", "tcp", not {transport}')
+		self.transport								= transport
+		"""	The transport protocol to use (tcp or websockets). """
+		self.websocketPath							= websocketPath
+		""" The websocket path to use (incase of websockets). """
 	
 	def shutdown(self) -> bool:
 		"""	Shutting down the MQTT client.
@@ -285,11 +299,20 @@ class MQTTConnection(object):
 		"""
 		self.messageHandler and self.messageHandler.logging(self, logging.DEBUG, f'MQTT: client name: {self.clientID}')
 		self.mqttClient = MQTTClient(callback_api_version = mqtt.CallbackAPIVersion.VERSION2,
-							   		 client_id = self.clientID, 
-									 clean_session = False if self.clientID else True)	# clean_session=False is defined by TS-0010
+							   		 client_id = self.clientID,
+									 transport=self.transport, 
+									 clean_session = False if self.clientID else True
+									 )	# clean_session=False is defined by TS-0010
 
-		# Enable SSL see: https://pypi.org/project/paho-mqtt/
-		if self.useTLS:
+		# Configure TLS for WebSocket connections
+		if self.transport == "websockets":
+			if self.verifyCertificate:
+				self.mqttClient.tls_set()
+			else:
+				self.mqttClient.tls_set(cert_reqs=ssl.CERT_NONE)  # Accept self-signed certificates 
+			self.mqttClient.ws_set_options(path=self.websocketPath if self.websocketPath else "/")
+		# Configure TLS for regular MQTT connections
+		elif self.useTLS:
 			self.mqttClient.tls_set(ca_certs = self.caFile, 
 									certfile = self.mqttsCertfile, 
 									keyfile = self.mqttsKeyfile, 
@@ -332,7 +355,20 @@ class MQTTConnection(object):
 		self.isStopped = False
 		self.messageHandler and self.messageHandler.logging(self, logging.INFO, 'MQTT: client started')
 		while not self.isStopped:
-			self.mqttClient.loop_forever()	# Will return when disconnect() is called
+			try:
+				self.mqttClient.loop_forever()	# Will return when disconnect() is called
+				# If loop_forever() returns without stopping, attempt reconnection
+				if not self.isStopped:
+					self.messageHandler and self.messageHandler.logging(self, logging.WARNING, 
+						'MQTT: Connection lost, attempting to reconnect...')
+					time.sleep(1)  # Brief delay before retry
+				
+			except Exception as e:
+				if not self.isStopped:
+					self.messageHandler and self.messageHandler.logging(self, logging.ERROR, 
+						f'MQTT: Error in connection loop: {str(e)}')
+					time.sleep(5)  # Longer delay on errors
+    
 		if self.messageHandler:
 			self.messageHandler.onShutdown(self)
 		return True

--- a/acme/init/acme.ini.default
+++ b/acme/init/acme.ini.default
@@ -269,7 +269,13 @@ topicPrefix=
 ; Timeout when sending MQTT requests and waiting for responses.
 ; Default: see cse.requestExpirationDelta
 timeout=${cse:requestExpirationDelta}
-
+; Transport when you want to use websockets for mqtt
+; Default: tcp
+transport=tcp
+; WebsocketPath it is the enpoint where mqtt brokker is listening
+; Default is "" empty string
+websocketPath=
+;allow self signed certificate for websocket
 
 ;
 ;	MQTT security settings

--- a/acme/protocols/MQTTClient.py
+++ b/acme/protocols/MQTTClient.py
@@ -332,7 +332,8 @@ class MQTTClient(object):
 													   port		= Configuration.mqtt_port,
 													   useTLS	= Configuration.mqtt_security_useTLS,
 													   username = Configuration.mqtt_security_username,
-													   password	= Configuration.mqtt_security_password)
+													   password	= Configuration.mqtt_security_password,
+													   transport= Configuration.mqtt_transport)
 		""" The MQTT connection. """
 
 		L.isInfo and L.log('MQTT Client initialized')
@@ -424,7 +425,7 @@ class MQTTClient(object):
 		return waitFor(Configuration.mqtt_timeout, lambda:self.mqttConnection.isConnected)
 
 
-	def connectToMqttBroker(self, address:str, port:int, useTLS:bool, username:Optional[str], password:Optional[str]) -> Optional[MQTTConnection]:
+	def connectToMqttBroker(self, address:str, port:int, useTLS:bool, username:Optional[str], password:Optional[str], transport:Optional[str]="tcp") -> Optional[MQTTConnection]:
 		"""	Connect to a oneM2M MQTT Broker. The connection is cached and reused. The key for identifying the
 			broker is a tupple (*address*, *port*). A new MQTTClientHandler() object be used for handling
 			requests.
@@ -442,7 +443,9 @@ class MQTTClient(object):
 												username 			= username,
 												password			= password,
 												lowLevelLogging 	= L.enableBindingsLogging,
-												messageHandler 		= MQTTClientHandler	(self))
+												messageHandler 		= MQTTClientHandler	(self),
+												transport			= Configuration.mqtt_transport,
+												websocketPath		= Configuration.mqtt_websocket_path)
 				if mqttConnection:
 					self.mqttConnections[(address, port)] = mqttConnection
 			return mqttConnection

--- a/acme/runtime/Configuration.py
+++ b/acme/runtime/Configuration.py
@@ -396,6 +396,8 @@ class Configuration(object):
 	mqtt_topicPrefix:str
 	"""	The topic prefix for MQTT. """
 
+	mqtt_transport:str
+	"""	The transport protocol for MQTT. """
 
 	mqtt_security_allowedCredentialIDs:list[str]
 	"""	The allowed credential IDs for MQTT. """
@@ -415,6 +417,8 @@ class Configuration(object):
 	mqtt_security_verifyCertificate:bool
 	"""	Enable or disable certificate verification for MQTT. """
 
+	mqtt_websocket_path:str
+	"""	The WebSocket path for MQTT. """
 
 	resource_acp_selfPermission:int
 	"""	The self permission for ACP. """

--- a/acme/runtime/Onboarding.py
+++ b/acme/runtime/Onboarding.py
@@ -608,7 +608,22 @@ def buildUserConfigFile(configFile:Optional[str],
 							message = 'MQTT broker password:',
 							long_instruction = 'The password to connect to the MQTT broker. Leave empty for no authentication.',
 							amark = '✓', 
-						).execute()
+						).execute(),
+				'transport': (transport := inquirer.text(
+							message = 'MQTT transport protocol:',
+							default= 'tcp',
+							long_instruction = 'The transport protocol for mqtt only could be "tcp" or "websockets".',
+							validate = lambda result: result in ['tcp', 'websockets'] or _containsVariable(result),
+							amark = '✓',
+						).execute()),
+				**({
+					'websocketPath': inquirer.text(
+                message='WebSocket path:',
+                default='/',
+                long_instruction='The WebSocket path for MQTT over WebSockets connection.',
+                amark='✓',
+            ).execute()
+        		} if transport == 'websockets' or (_containsVariable(transport) and 'websockets' in transport) else {})
 			}
 		
 		if 'CoAP' in bindings:
@@ -857,6 +872,11 @@ f"""
 enable=true
 address={bindings['mqtt']['address']}
 port={bindings['mqtt']['port']}
+transport={bindings['mqtt']['transport']}
+websocketPath={bindings['mqtt']['websocketPath'] if bindings['mqtt']['transport'] == 'websockets' else 'None'}
+"""
+			if bindings['mqtt']['transport'] == 'tcp':
+				jcnf += f"""
 """
 			if bindings['mqtt']['username']:
 				jcnf += f"""

--- a/acme/runtime/configurations/MQTTConfiguration.py
+++ b/acme/runtime/configurations/MQTTConfiguration.py
@@ -42,6 +42,8 @@ class MQTTConfiguration(ModuleConfiguration):
 		config.mqtt_security_username = parser.get('mqtt.security', 'username', fallback = '')
 		config.mqtt_security_useTLS = parser.getboolean('mqtt.security', 'useTLS', fallback = False)
 		config.mqtt_security_verifyCertificate = parser.getboolean('mqtt.security', 'verifyCertificate', fallback = False)
+		config.mqtt_transport = parser.get('mqtt', 'transport', fallback = 'tcp')	# Transport protocol (tcp, websockets)
+		config.mqtt_websocket_path = parser.get('mqtt', 'websocketPath', fallback = None)
 
 
 	def validateConfiguration(self, config:Configuration, initial:Optional[bool] = False) -> None:


### PR DESCRIPTION
# PR for Issue #177: Add MQTT WebSocket Support in ACME

This PR adds support for MQTT over WebSocket in ACME to enable integration with the MEC Sandbox. While the `paho` client already provides WebSocket support, it had to be integrated and configured within ACME.  

## Commit Breakdown  

1. **Integration of WebSocket support**  
   - Added WebSocket handling in the MQTT helper connection file and the MQTT client file.  

2. **Configuration settings**  
   - Introduced configuration options for enabling MQTT over WebSocket.  

3. **.gitignore update**  
   - Added `.venv` to `.gitignore` for better virtual environment management.  

4. **MQTT connection stability fix**  
   - Resolved an issue where the MQTT client repeatedly disconnected and reconnected.  
   - **Root cause:** default keep-alive was set to 60s.  
   - **Solution:** lowered the default keep-alive interval to **45s**, which eliminated the issue.  

5. **Onboarding updates**  
   - Updated `onboarding.py` to include parameters for MQTT over WebSocket.  
   - Ensures that `transport` and `websocket_path` variables are generated correctly in `acme.ini`.  
